### PR TITLE
Treat warnings as errors and centralise build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ RecipeManager/.idea
 
 # JetBrains Rider per-user settings
 *.DotSettings.user
+
+# Visual Studio per-user project settings (debug profile, start action)
+*.user

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ Full detail and rationale: [docs/tech-stack.md](docs/tech-stack.md).
   RecipeManager/                     solution root — run all dotnet commands from here
     RecipeManager.sln
     global.json                      pins SDK 10.0.302, rollForward: latestFeature
+    Directory.Build.props            TargetFramework/Nullable/ImplicitUsings + TreatWarningsAsErrors, all projects
     RecipeManager.Domain/            Recipe entity, Entity base, RecipeErrors, IRecipeRepository
     RecipeManager.Application/       Commands, Queries, Handlers, Dispatchers, DTOs, Validators, Mappings
     RecipeManager.Infrastructure/    AppDbContext, RecipeRepository, CachedRecipeRepository, MemoryCacheService, Migrations
@@ -111,10 +112,10 @@ dotnet build RecipeManager.sln
 dotnet test RecipeManager.sln
 ```
 
-Current state: build succeeds with **7 warnings** (all in `RecipeManager.UnitTests`) and **84 tests pass**
-(70 unit + 14 integration). **Those 7 warnings are known defects, not an acceptable baseline** — see
-`BUILD-01` and `BUILD-02` in [docs/known-issues.md](docs/known-issues.md). The target is zero warnings in every
-project. Never add a new one.
+Current state: build succeeds with **0 warnings** and **84 tests pass** (70 unit + 14 integration).
+`RecipeManager/Directory.Build.props` sets `TreatWarningsAsErrors` for every project (ADR-010), so a warning is
+a **build failure**, not a note — and `TargetFramework`, `Nullable`, and `ImplicitUsings` live there too. Never
+re-declare those in a `.csproj`.
 
 Frontend checks are in worse shape than they look: `npm run lint` **cannot run at all** on a clean install, and
 `npm run build` does not type-check (`BUILD-03`, `BUILD-04`). Read those entries before trusting a green
@@ -225,8 +226,9 @@ API first; there is no mock backend.
 2. **Never commit secrets.** No connection-string passwords, API keys, or tokens in `appsettings*.json`,
    `.env*`, or source. Use `dotnet user-secrets` or environment variables. The committed connection string is a
    deliberately password-free template — keep it that way.
-3. **Tests must pass and warnings must not grow before a PR.** `dotnet test RecipeManager.sln` from
-   `RecipeManager/`. Zero warnings is the target; adding one is a blocking review finding. There is no frontend
+3. **Tests must pass and the build must stay warning-free before a PR.** `dotnet test RecipeManager.sln` from
+   `RecipeManager/`. Warnings are errors (ADR-010), so a new one breaks the build rather than merely being a
+   blocking review finding. Suppressing one to get moving needs a stated reason. There is no frontend
    test runner yet — see [docs/agents/06-qa-tester.md](docs/agents/06-qa-tester.md).
 4. **Respect the dependency direction.** `Domain ← Application ← Infrastructure ← Api`. Domain references no
    project. Any deviation is an architecture decision, not an implementation detail.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ Full detail and rationale: [docs/tech-stack.md](docs/tech-stack.md).
     RecipeManager.sln
     global.json                      pins SDK 10.0.302, rollForward: latestFeature
     Directory.Build.props            TargetFramework/Nullable/ImplicitUsings + TreatWarningsAsErrors, all projects
+    Directory.Packages.props         every package version (central package management) — never version a .csproj
     RecipeManager.Domain/            Recipe entity, Entity base, RecipeErrors, IRecipeRepository
     RecipeManager.Application/       Commands, Queries, Handlers, Dispatchers, DTOs, Validators, Mappings
     RecipeManager.Infrastructure/    AppDbContext, RecipeRepository, CachedRecipeRepository, MemoryCacheService, Migrations

--- a/RecipeManager/Directory.Build.props
+++ b/RecipeManager/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+</Project>

--- a/RecipeManager/Directory.Packages.props
+++ b/RecipeManager/Directory.Packages.props
@@ -1,0 +1,35 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Ardalis.GuardClauses" Version="5.0.0" />
+    <PackageVersion Include="FluentResults" Version="3.16.0" />
+    <PackageVersion Include="FluentValidation" Version="11.11.0" />
+    <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
+    <PackageVersion Include="Scrutor" Version="7.0.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+  </ItemGroup>
+
+  <!-- Test-only packages -->
+  <ItemGroup>
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
+    <PackageVersion Include="FluentAssertions" Version="8.10.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="NSubstitute" Version="6.0.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
+</Project>

--- a/RecipeManager/RecipeManager.Api/RecipeManager.Api.csproj
+++ b/RecipeManager/RecipeManager.Api/RecipeManager.Api.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>3fd489a5-aeb3-47b7-bb4b-1fcf640ac7cc</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>

--- a/RecipeManager/RecipeManager.Api/RecipeManager.Api.csproj
+++ b/RecipeManager/RecipeManager.Api/RecipeManager.Api.csproj
@@ -6,17 +6,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.11.0" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
+    <PackageReference Include="FluentValidation" />
+    <PackageReference Include="FluentValidation.AspNetCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-    <PackageReference Include="Scrutor" Version="7.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
+    <PackageReference Include="Scrutor" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RecipeManager/RecipeManager.Api/RecipeManager.Api.csproj.user
+++ b/RecipeManager/RecipeManager.Api/RecipeManager.Api.csproj.user
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <ActiveDebugProfile>Container (Dockerfile)</ActiveDebugProfile>
-  </PropertyGroup>
-</Project>

--- a/RecipeManager/RecipeManager.Application/RecipeManager.Application.csproj
+++ b/RecipeManager/RecipeManager.Application/RecipeManager.Application.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="FluentResults" Version="3.16.0" />
-    <PackageReference Include="FluentValidation" Version="11.11.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="FluentResults" />
+    <PackageReference Include="FluentValidation" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RecipeManager/RecipeManager.Application/RecipeManager.Application.csproj
+++ b/RecipeManager/RecipeManager.Application/RecipeManager.Application.csproj
@@ -1,11 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="FluentResults" Version="3.16.0" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />

--- a/RecipeManager/RecipeManager.Domain/RecipeManager.Domain.csproj
+++ b/RecipeManager/RecipeManager.Domain/RecipeManager.Domain.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
-    <PackageReference Include="FluentResults" Version="3.16.0" />
+    <PackageReference Include="Ardalis.GuardClauses" />
+    <PackageReference Include="FluentResults" />
   </ItemGroup>
 
 </Project>

--- a/RecipeManager/RecipeManager.Domain/RecipeManager.Domain.csproj
+++ b/RecipeManager/RecipeManager.Domain/RecipeManager.Domain.csproj
@@ -1,11 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
     <PackageReference Include="FluentResults" Version="3.16.0" />

--- a/RecipeManager/RecipeManager.Infrastructure/RecipeManager.Infrastructure.csproj
+++ b/RecipeManager/RecipeManager.Infrastructure/RecipeManager.Infrastructure.csproj
@@ -10,13 +10,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>
 
 </Project>

--- a/RecipeManager/RecipeManager.Infrastructure/RecipeManager.Infrastructure.csproj
+++ b/RecipeManager/RecipeManager.Infrastructure/RecipeManager.Infrastructure.csproj
@@ -1,11 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\RecipeManager.Application\RecipeManager.Application.csproj" />
     <ProjectReference Include="..\RecipeManager.Domain\RecipeManager.Domain.csproj" />

--- a/RecipeManager/RecipeManager.IntegrationTests/RecipeManager.IntegrationTests.csproj
+++ b/RecipeManager/RecipeManager.IntegrationTests/RecipeManager.IntegrationTests.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/RecipeManager/RecipeManager.IntegrationTests/RecipeManager.IntegrationTests.csproj
+++ b/RecipeManager/RecipeManager.IntegrationTests/RecipeManager.IntegrationTests.csproj
@@ -6,13 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1" />
-    <PackageReference Include="FluentAssertions" Version="8.10.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RecipeManager/RecipeManager.UnitTests/Application/Handlers/CreateRecipeHandlerTests.cs
+++ b/RecipeManager/RecipeManager.UnitTests/Application/Handlers/CreateRecipeHandlerTests.cs
@@ -52,7 +52,7 @@ public class CreateRecipeHandlerTests
         result.Value.Id.Should().NotBeEmpty();
 
         await _recipeRepository.Received(1).AddAsync(
-            Arg.Is<Recipe>(r => r.Title == command.Title),
+            Arg.Is<Recipe>(r => r != null && r.Title == command.Title),
             Arg.Any<CancellationToken>());
     }
 

--- a/RecipeManager/RecipeManager.UnitTests/Application/Handlers/DeleteRecipeHandlerTests.cs
+++ b/RecipeManager/RecipeManager.UnitTests/Application/Handlers/DeleteRecipeHandlerTests.cs
@@ -53,7 +53,7 @@ public class DeleteRecipeHandlerTests
         await _recipeRepository.Received(1).GetByIdAsync(recipeId, Arg.Any<CancellationToken>());
 
         await _recipeRepository.Received(1).DeleteAsync(
-            Arg.Is<Recipe>(r => r.Id == existingRecipe.Id),
+            Arg.Is<Recipe>(r => r != null && r.Id == existingRecipe.Id),
             Arg.Any<CancellationToken>());
     }
 

--- a/RecipeManager/RecipeManager.UnitTests/Application/Handlers/UpdateRecipeHandlerTest.cs
+++ b/RecipeManager/RecipeManager.UnitTests/Application/Handlers/UpdateRecipeHandlerTest.cs
@@ -60,6 +60,7 @@ public class UpdateRecipeHandlerTest
 
         await _recipeRepository.Received(1).UpdateAsync(
             Arg.Is<Recipe>(r =>
+                r != null &&
                 r.Title == command.Title &&
                 r.Description == command.Description &&
                 r.PreparationTime == command.PreparationTime &&
@@ -230,6 +231,7 @@ public class UpdateRecipeHandlerTest
 
         await _recipeRepository.Received(1).UpdateAsync(
             Arg.Is<Recipe>(r =>
+                r != null &&
                 r.PreparationTime == command.PreparationTime &&
                 r.CookingTime == 0),
             Arg.Any<CancellationToken>());
@@ -272,6 +274,7 @@ public class UpdateRecipeHandlerTest
 
         await _recipeRepository.Received(1).UpdateAsync(
             Arg.Is<Recipe>(r =>
+                r != null &&
                 r.PreparationTime == 0 &&
                 r.CookingTime == command.CookingTime),
             Arg.Any<CancellationToken>());

--- a/RecipeManager/RecipeManager.UnitTests/Domain/Entities/RecipeTests.cs
+++ b/RecipeManager/RecipeManager.UnitTests/Domain/Entities/RecipeTests.cs
@@ -76,14 +76,14 @@ public class RecipeTests
     [InlineData(null)]
     [InlineData("")] 
     [InlineData("   ")] 
-    public void Create_WithInvalidTitle_ShouldReturnFailureResult(string invalidTitle)
+    public void Create_WithInvalidTitle_ShouldReturnFailureResult(string? invalidTitle)
     {
         // Arrange
         var ingredients = new List<string> { "Flour" };
         var instructions = new List<string> { "Mix" };
 
         // Act
-        Result<Recipe> result = Recipe.Create(invalidTitle, "Description",
+        Result<Recipe> result = Recipe.Create(invalidTitle!, "Description",
             10, 20, 2, ingredients, instructions);
 
         // Assert
@@ -96,14 +96,14 @@ public class RecipeTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
-    public void Create_WithInvalidDescription_ShouldReturnFailureResult(string invalidDescription)
+    public void Create_WithInvalidDescription_ShouldReturnFailureResult(string? invalidDescription)
     {
         // Arrange
         var ingredients = new List<string> { "Flour" };
         var instructions = new List<string> { "Mix" };
 
         // Act
-        Result<Recipe> result = Recipe.Create("Title", invalidDescription,
+        Result<Recipe> result = Recipe.Create("Title", invalidDescription!,
             10, 20, 2, ingredients, instructions);
 
         // Assert

--- a/RecipeManager/RecipeManager.UnitTests/RecipeManager.UnitTests.csproj
+++ b/RecipeManager/RecipeManager.UnitTests/RecipeManager.UnitTests.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/RecipeManager/RecipeManager.UnitTests/RecipeManager.UnitTests.csproj
+++ b/RecipeManager/RecipeManager.UnitTests/RecipeManager.UnitTests.csproj
@@ -6,16 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1" />
-    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="coverlet.msbuild">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="NSubstitute" Version="6.0.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/agents/00-leader.md
+++ b/docs/agents/00-leader.md
@@ -89,8 +89,8 @@ Do not hand off to the user until:
 
 - [ ] The spec in `docs/specs/` matches what was actually built.
 - [ ] Every decomposed item above was assigned and completed, or explicitly dropped with a reason.
-- [ ] `dotnet build` and `dotnet test` were run and the numbers reported (currently 7 warnings — target 0 —
-      and 84 passing).
+- [ ] `dotnet build` and `dotnet test` were run and the numbers reported (0 warnings — enforced by
+      `TreatWarningsAsErrors`, ADR-010 — and 84 passing).
 - [ ] [../known-issues.md](../known-issues.md) updated: fixed entries deleted, new findings added.
 - [ ] [../decisions-log.md](../decisions-log.md) has an entry if the work contained a decision worth
       remembering, a lesson from a bug, or a reversal of an earlier call.

--- a/docs/agents/02-senior-csharp.md
+++ b/docs/agents/02-senior-csharp.md
@@ -85,6 +85,15 @@ Domain/Application/Infrastructure/Api, or backend test work.
 - [ ] Verify the resulting status code end-to-end: `ErrorCode` metadata drives it, and only `errors.First()`
       sets the response status.
 
+### Packages
+
+- [ ] A new package is **two** edits (ADR-011): `<PackageVersion Include="X" Version="N" />` in
+      `RecipeManager/Directory.Packages.props`, and `<PackageReference Include="X" />` — **no `Version`** — in
+      the project that needs it. A `Version` in a `.csproj` fails the build with `NU1008`.
+- [ ] Never re-declare `TargetFramework`, `Nullable`, `ImplicitUsings`, or the warning properties in a
+      `.csproj`; `Directory.Build.props` owns them (ADR-010).
+- [ ] A new dependency still needs `01-architect` sign-off — central versioning makes it *tidy*, not automatic.
+
 ### Async & nullability
 
 - [ ] `async Task` / `async Task<T>`; `CancellationToken` last and non-optional on new interface members.

--- a/docs/agents/02-senior-csharp.md
+++ b/docs/agents/02-senior-csharp.md
@@ -101,9 +101,8 @@ Domain/Application/Infrastructure/Api, or backend test work.
 - [ ] New endpoint ⇒ integration test in `RecipeManager.IntegrationTests/RecipesControllerTests.cs` asserting status code
       **and** database state, with `DbContext.ChangeTracker.Clear()` before post-write assertions.
 - [ ] FluentAssertions only, never `Assert.*`. AAA markers required.
-- [ ] `dotnet test RecipeManager.sln` — currently 84 passing. **Zero build warnings is the standard**; the 7 that
-      exist today are defects (`BUILD-01`, `BUILD-02` in [../known-issues.md](../known-issues.md)), so never add
-      one and clear an existing one when you are already in that file.
+- [ ] `dotnet test RecipeManager.sln` — currently 84 passing. **Zero build warnings, enforced** by
+      `TreatWarningsAsErrors` (ADR-010): a warning fails the build. Fix the cause; do not suppress it.
 
 ### Performance notes for this codebase
 

--- a/docs/agents/04-code-reviewer.md
+++ b/docs/agents/04-code-reviewer.md
@@ -107,7 +107,8 @@ required — then security reviews after code review.
 - `React.FC` vs. plain destructured props — both exist in the codebase.
 - A default export added alongside a named export on a new component.
 - Duplication that has appeared twice but not yet three times.
-- A property re-declared in a `.csproj` that `Directory.Build.props` already owns (ADR-010).
+- A property re-declared in a `.csproj` that `Directory.Build.props` already owns (ADR-010). A package version
+  in a `.csproj` cannot slip past review — it fails the build (`NU1008`, ADR-011).
 - A finding worth recording that is out of scope for this PR — ask for an entry in
   [../known-issues.md](../known-issues.md) rather than a code comment.
 

--- a/docs/agents/04-code-reviewer.md
+++ b/docs/agents/04-code-reviewer.md
@@ -19,8 +19,9 @@ required — then security reviews after code review.
 
 ### 0. Verify, don't trust
 
-- [ ] `dotnet build RecipeManager.sln` — currently **7 warnings** (`BUILD-01`, `BUILD-02`). **Zero is the
-      standard**; any *new* warning is a Block, and a PR that clears an existing one is a win worth saying so.
+- [ ] `dotnet build RecipeManager.sln` — must be **0 warnings**, enforced by `TreatWarningsAsErrors` (ADR-010),
+      so a warning arrives as a build failure. A `#pragma warning disable` or a `NoWarn` entry added to get past
+      it is a **Block** unless the PR states why the warning is wrong.
 - [ ] `dotnet test RecipeManager.sln` — **84 passing** is the current count. Fewer than before with no
       explanation is a Block.
 - [ ] Frontend touched ⇒ `npm run build` **and** `npx tsc --noEmit`. `npm run build` does not type-check
@@ -106,7 +107,7 @@ required — then security reviews after code review.
 - `React.FC` vs. plain destructured props — both exist in the codebase.
 - A default export added alongside a named export on a new component.
 - Duplication that has appeared twice but not yet three times.
-- Opportunities to clear one of the 7 outstanding build warnings while already in that file.
+- A property re-declared in a `.csproj` that `Directory.Build.props` already owns (ADR-010).
 - A finding worth recording that is out of scope for this PR — ask for an entry in
   [../known-issues.md](../known-issues.md) rather than a code comment.
 
@@ -114,7 +115,7 @@ required — then security reviews after code review.
 
 ```md
 ## Verification
-build: <N> warnings (7 today, target 0) · test: <N>/<N> (78 today) · npm build + tsc: pass | n/a
+build: <N> warnings (must be 0) · test: <N>/<N> (84 today) · npm build + tsc: pass | n/a
 known-issues: fixed <IDs> · added <IDs>
 
 ## Blocking

--- a/docs/agents/06-qa-tester.md
+++ b/docs/agents/06-qa-tester.md
@@ -29,10 +29,10 @@ though QA can block on missing coverage).
 Unit-test breakdown: `RecipeTests` 18, `CreateRecipeHandlerTests` 11, `GetAllRecipesHandlerTests` 8,
 `EntityTests` 8, `DeleteRecipeHandlerTests` 7, `GetRecipeByIdHandlerTests` 7, `UpdateRecipeHandlerTest` 6.
 
-Build: **7 warnings**, all in `RecipeManager.UnitTests` — five `CS8602` from NSubstitute 6's nullable
-`Arg.Is<T>` predicate and two `xUnit1012` from `[InlineData(null)]` on a non-nullable `string` parameter.
-**These are defects to fix, not a baseline to preserve** (`BUILD-01`, `BUILD-02` in
-[../known-issues.md](../known-issues.md)); the target is a warning-free build.
+Build: **0 warnings**, enforced — `TreatWarningsAsErrors` in `Directory.Build.props` (ADR-010). Test code is
+where warnings historically accumulated, so two idioms exist to keep it clean: null-guard inside an
+`Arg.Is<T>` predicate (`r => r != null && r.Title == …`), and a nullable parameter on any `[Theory]` carrying
+`[InlineData(null)]`. See [../conventions.md](../conventions.md#tests).
 
 ```bash
 dotnet test RecipeManager.sln
@@ -83,7 +83,7 @@ the reported number, so it understates real coverage — `BUILD-06` in [../known
       repository interaction.
 - [ ] Every new or changed endpoint: an integration test asserting status code **and** database state.
 - [ ] Every bug fix: a test that fails without the fix.
-- [ ] No new build warnings, and ideally one fewer.
+- [ ] Build is warning-free — it fails otherwise, so never reach for `#pragma warning disable` to get green.
 
 No numeric coverage threshold has ever been agreed — `TEST-05` in [../known-issues.md](../known-issues.md).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -264,6 +264,30 @@ endpoint is anonymous and every recipe is world-writable. See
   `ResultExtensions`, with the existing integration tests as the regression net — externally visible status
   codes must not change.
 
+### ADR-010 — Warnings are errors, and project properties are centralised
+
+- **Status:** accepted and **implemented 2026-08-04** (`R-02`). Closes `BUILD-01` and `BUILD-02`.
+- **Context:** `TargetFramework`, `Nullable`, and `ImplicitUsings` were duplicated across all six `.csproj`
+  files, and nothing stopped a warning from being committed. Seven had accumulated since the .NET 10 upgrade and
+  survived several PRs, because a warning is only a note in scrollback that everyone learns to skip.
+- **Decision:** `RecipeManager/Directory.Build.props` owns `TargetFramework`, `Nullable`, `ImplicitUsings`,
+  `TreatWarningsAsErrors`, and `EnforceCodeStyleInBuild` for every project in the solution. The six `.csproj`
+  files keep only what is genuinely project-specific (`UserSecretsId`, `IsTestProject`, package references).
+  `TreatWarningsAsErrors` is **unconditional**, not scoped to Release: with no CI yet (`INFRA-01`, `R-04`), the
+  local Debug build is the only gate that exists, so a Release-only condition would enforce nothing.
+- **Consequences:** a warning now stops the build, so it must be fixed or explicitly suppressed with a stated
+  reason rather than accumulating. The cost is real: an unused local while mid-refactor fails the build, which
+  is friction exactly when iterating. That friction is the mechanism, not a side effect — the alternative is a
+  warning count that only ever goes up.
+  `EnforceCodeStyleInBuild` currently reports nothing, because IDE style rules default to suggestion severity
+  and there is no `.editorconfig`. It is a latch: the day an `.editorconfig` is added, style violations become
+  build failures without a further change. Verified by a deliberate negative test — an unused local produced
+  `error CS0219` and failed the build.
+- **Rejected:** *(a)* Release-only enforcement — frictionless locally, but enforces nothing until CI exists.
+  *(b)* Listing specific rule IDs in `WarningsAsErrors` — surgical, but it is a list somebody must maintain and
+  it cannot stop a new class of warning. *(c)* Fixing the seven warnings without the gate — leaves the count
+  free to grow back, which is the `BUILD-03` failure mode.
+
 ---
 
 These ADRs were **reconstructed from code and commit messages** — no ADR files existed before, so ADR-001

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -281,8 +281,42 @@ endpoint is anonymous and every recipe is world-writable. See
   warning count that only ever goes up.
   `EnforceCodeStyleInBuild` currently reports nothing, because IDE style rules default to suggestion severity
   and there is no `.editorconfig`. It is a latch: the day an `.editorconfig` is added, style violations become
-  build failures without a further change. Verified by a deliberate negative test — an unused local produced
-  `error CS0219` and failed the build.
+  build failures without a further change — which is why adding one is tracked as `R-15` rather than done
+  incidentally. Verified by a deliberate negative test — an unused local produced `error CS0219` and failed the
+  build.
+- **Also elevates NuGet restore warnings**, which is easy to miss: `TreatWarningsAsErrors` is honoured by
+  restore, not only by the compiler. Verified — a package with a published advisory produces
+  `error NU1903 … Warning As Error` and fails the build, and `NuGetAuditMode` defaults to `all` on .NET 10, so
+  **transitive** advisories count too. All six projects are clean today, so nothing breaks now; the consequence
+  is that a *newly published* advisory against any dependency will fail the build with no code change.
+  Accepted deliberately: it delivers, earlier and harder, the `dotnet list package --vulnerable` gate that
+  `R-04` plans for CI, and `SEC-03` (68 npm alerts nobody acts on) is the failure mode it prevents on the .NET
+  side. If it ever becomes obstructive the escape hatch is
+  `<WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>` — do not reach for it without
+  recording why.
+
+### ADR-011 — Central Package Management
+
+- **Status:** accepted and **implemented 2026-08-04**.
+- **Context:** ADR-010 removed duplicated *properties* from the `.csproj` files but left duplicated *versions*:
+  ten packages declared their version in two projects each — `Microsoft.EntityFrameworkCore` 10.0.10 and
+  `Npgsql.EntityFrameworkCore.PostgreSQL` 10.0.3 in both `Api` and `Infrastructure`, `FluentResults` in both
+  `Domain` and `Application`, and the whole xunit/FluentAssertions/coverlet set in both test projects.
+- **The failure this prevents.** Bumping EF Core in one project and not the other does not warn and does not
+  fail: NuGet resolves the conflict by nearest-wins and the mismatch surfaces at runtime, in whichever project
+  lost. That is strictly worse than the warning problem ADR-010 solved, because there is no diagnostic at all.
+- **Decision:** `RecipeManager/Directory.Packages.props` sets `ManagePackageVersionsCentrally` and holds every
+  version as a `PackageVersion` item. A `.csproj` names the packages it needs — `<PackageReference Include="…" />`
+  with **no** `Version` attribute — and keeps only per-project metadata (`PrivateAssets`, `IncludeAssets`).
+- **Consequences:** a version exists in exactly one place, so drift becomes unrepresentable rather than merely
+  discouraged — verified by a negative test: adding `Version=` back to a `.csproj` produces
+  `error NU1008` and fails the build. Upgrading a shared package is now a one-line edit, which also makes the
+  `R-04` vulnerability remediation loop single-edit. The cost is indirection: reading a `.csproj` no longer
+  tells you which version you get, and a newcomer who adds a `PackageReference` the usual way (with a version)
+  gets an error until they learn the convention — an error being the point.
+- **Rejected:** leaving versions in the `.csproj` files and relying on review to keep them aligned. That is the
+  same class of rule ADR-008 abandoned for handler registration: enforced only by attention, and it fails
+  silently.
 - **Rejected:** *(a)* Release-only enforcement — frictionless locally, but enforces nothing until CI exists.
   *(b)* Listing specific rule IDs in `WarningsAsErrors` — surgical, but it is a list somebody must maintain and
   it cannot stop a new class of warning. *(c)* Fixing the seven warnings without the gate — leaves the count

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -28,6 +28,11 @@ Legend: **⚠ Target** marks a rule that the current code does not yet satisfy e
   in `RecipeManager/Directory.Build.props` and apply to every project (ADR-010). **Never re-declare them in a
   `.csproj`** — a project file carries only what is specific to it (`UserSecretsId`, `IsTestProject`, package
   and project references). A new project needs no boilerplate; it inherits the lot.
+- **Package versions live in `RecipeManager/Directory.Packages.props`, never in a `.csproj`** (ADR-011). Adding
+  a package is two edits: a `<PackageVersion Include="X" Version="N" />` there, and a bare
+  `<PackageReference Include="X" />` — **no `Version` attribute** — in the project that needs it. Per-project
+  metadata (`PrivateAssets`, `IncludeAssets`) stays on the `PackageReference`. A `Version` in a `.csproj` is
+  `error NU1008`, so this is enforced rather than remembered.
 
 ### Naming
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -24,9 +24,10 @@ Legend: **⚠ Target** marks a rule that the current code does not yet satisfy e
   newer ones (`RecipeErrors`, `ResultExtensions`, `CachedRecipeRepository`, validators, dispatchers) are
   already file-scoped. Convert an old file only when you are already changing it substantially — never as a
   standalone reformat commit.
-- `<Nullable>enable</Nullable>` and `<ImplicitUsings>enable</ImplicitUsings>` in every project.
-  **⚠ Target:** these are duplicated across all six `.csproj` files and should move to a single
-  `Directory.Build.props`, together with `TreatWarningsAsErrors` (`R-02` in [roadmap.md](roadmap.md)).
+- `TargetFramework`, `Nullable`, `ImplicitUsings`, `TreatWarningsAsErrors`, and `EnforceCodeStyleInBuild` live
+  in `RecipeManager/Directory.Build.props` and apply to every project (ADR-010). **Never re-declare them in a
+  `.csproj`** — a project file carries only what is specific to it (`UserSecretsId`, `IsTestProject`, package
+  and project references). A new project needs no boilerplate; it inherits the lot.
 
 ### Naming
 
@@ -246,11 +247,15 @@ on images.
 - Integration tests derive from `IntegrationTestBase`, get a fresh InMemory database per test
   (`TestDb_{Guid}`), seed via `SeedDatabase(...)`, and call `DbContext.ChangeTracker.Clear()` before asserting
   post-write state.
-- **Zero warnings is the standard.** The build currently emits 7, all in `RecipeManager.UnitTests`: five
-  `CS8602` from NSubstitute 6's nullable `Arg.Is<T>` predicate, and two `xUnit1012` from `[InlineData(null)]` on
-  a non-nullable `string` parameter. These are tracked as defects to fix (`BUILD-01`, `BUILD-02` in
-  [known-issues.md](known-issues.md)), **not** as an accepted baseline. Never add a new warning, and prefer
-  clearing an existing one when you are already editing that file.
+- **Zero warnings, enforced.** `TreatWarningsAsErrors` is on for every project (ADR-010), so a warning fails the
+  build rather than accumulating. Two idioms exist because of this, both from the NSubstitute 6 / xUnit analyser
+  set:
+  - Null-guard inside an `Arg.Is<T>` predicate — `Arg.Is<Recipe>(r => r != null && r.Title == command.Title)` —
+    because NSubstitute 6 annotates the predicate parameter as nullable. Do not use `r!` or
+    `#pragma warning disable`; the guard also makes the assertion honest.
+  - A `[Theory]` with `[InlineData(null)]` takes a **nullable** parameter (`string? invalidTitle`) and
+    null-forgives at the call site (`Recipe.Create(invalidTitle!, …)`). `!` is correct there and only there:
+    passing null *is* the scenario under test.
 
 ### Frontend
 

--- a/docs/decisions-log.md
+++ b/docs/decisions-log.md
@@ -76,6 +76,12 @@ confirmed it actually fails. `BUILD-03` is this project's own proof of why: `npm
 *start* for eleven months and nobody noticed, because an unrun check and a passing check look identical from
 outside.
 
+**Follow-on, same PR.** Having removed the duplicated *properties*, the obvious next question was what else was
+duplicated — and it was every package **version**: ten of them declared in two projects each. That one is worse,
+because bumping EF Core in `Infrastructure` and not `Api` produces no warning at all; NuGet resolves
+nearest-wins and the mismatch appears at runtime. Fixed with central package management (ADR-011), and verified
+the same way: putting a `Version` back into a `.csproj` now gives `error NU1008`.
+
 **Takeaway.** *Turn "should" into "cannot".* The gap between a documented standard and an enforced one is
 filled entirely by human attention, which is the least reliable component available — and the failure is silent
 by construction, since nothing reports the warnings you stopped reading. Then verify the enforcement by

--- a/docs/decisions-log.md
+++ b/docs/decisions-log.md
@@ -42,11 +42,46 @@ Jump to every entry touching a topic.
 | Domain modelling | [2026-07-26 Structured ingredients](#2026-07-26--free-text-ingredients-are-a-shortcut-with-an-expiry-date) |
 | Testing | [2026-07-26 Testcontainers](#2026-07-26--ef-inmemory-is-not-a-database), [2025-10-08 Integration tests](#2025-10-08--integration-tests-need-an-escape-hatch-and-escape-hatches-need-guards) |
 | Project direction | [2026-07-26 Project stance](#2026-07-26--practice-project-with-deployment-intent) |
-| Tooling / infrastructure | [2026-07-25 .NET 10 + PostgreSQL](#2026-07-25--net-10-and-postgresql) |
+| Tooling / infrastructure | [2026-08-04 Warnings as errors](#2026-08-04--a-warning-nobody-has-to-fix-is-a-warning-that-multiplies), [2026-07-25 .NET 10 + PostgreSQL](#2026-07-25--net-10-and-postgresql) |
+| Enforcement vs. convention | [2026-08-04 Warnings as errors](#2026-08-04--a-warning-nobody-has-to-fix-is-a-warning-that-multiplies), [2026-07-26 Scrutor](#2026-07-26--auto-register-handlers-instead-of-listing-them), [2025-10-08 Integration tests](#2025-10-08--integration-tests-need-an-escape-hatch-and-escape-hatches-need-guards) |
 
 ---
 
 ## Entries
+
+### 2026-08-04 — A warning nobody has to fix is a warning that multiplies
+
+**Context.** Seven build warnings had sat in `RecipeManager.UnitTests` since the .NET 10 upgrade
+(`BUILD-01`, `BUILD-02`). Every one was a ~2-minute fix. They survived several PRs anyway, because a warning is
+a line of scrollback between "Build succeeded" and the prompt, and the correct number of those to read is zero.
+Meanwhile `TargetFramework`, `Nullable`, and `ImplicitUsings` were copy-pasted into all six `.csproj` files.
+
+**Decision.** Fix the seven, then add `RecipeManager/Directory.Build.props` owning those three properties plus
+`TreatWarningsAsErrors` and `EnforceCodeStyleInBuild` — **unconditionally, not Release-only**. ADR-010, `R-02`.
+
+**Rejected.** *(a)* Release-only enforcement, the common advice: it keeps local iteration frictionless and
+matches what CI would run. Wrong **here** specifically, because there is no CI (`INFRA-01`) — the local Debug
+build is the only gate that exists, so conditioning on Release would have enforced nothing while looking like a
+control. *(b)* Fixing the seven warnings and stopping there — the count is then free to grow straight back.
+*(c)* An explicit `WarningsAsErrors` rule list: surgical, but somebody has to maintain it and it cannot catch a
+new class of warning.
+
+**Cost.** Real and daily: an unused local while mid-refactor now fails the build. That friction *is* the
+mechanism — the whole point is that the fix cannot be deferred. `EnforceCodeStyleInBuild` also currently
+reports nothing (IDE rules default to suggestion severity with no `.editorconfig`); it is a latch that arms
+itself the day one is added, which is worth knowing so nobody assumes style is being checked today.
+
+**The step that mattered.** After adding the gate, a deliberate broken build — an unused local, `CS0219` —
+confirmed it actually fails. `BUILD-03` is this project's own proof of why: `npm run lint` had been unable to
+*start* for eleven months and nobody noticed, because an unrun check and a passing check look identical from
+outside.
+
+**Takeaway.** *Turn "should" into "cannot".* The gap between a documented standard and an enforced one is
+filled entirely by human attention, which is the least reliable component available — and the failure is silent
+by construction, since nothing reports the warnings you stopped reading. Then verify the enforcement by
+breaking it on purpose: a gate you have never seen reject anything is indistinguishable from no gate.
+
+---
 
 ### 2026-07-26 — Free-text ingredients are a shortcut with an expiry date
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -637,3 +637,6 @@ Decisions that were open and are now answered, kept so they are not re-litigated
 | Integration tests: EF InMemory or a real database? | **Testcontainers with real PostgreSQL**, deferred until CI exists. | `R-06` |
 | `BUILD-01`, `BUILD-02` — 7 backend build warnings | **Fixed**, and made unrepeatable by `TreatWarningsAsErrors` in `Directory.Build.props`. **Shipped 2026-08-04.** | ADR-010 |
 | Should warnings-as-errors be Release-only? | **No — every configuration.** There is no CI yet (`INFRA-01`), so a Release-only condition would enforce nothing. | ADR-010 |
+| Package versions duplicated across `.csproj` files | **Central package management.** Ten packages were versioned in two projects each; drift resolved nearest-wins with no diagnostic. **Shipped 2026-08-04.** | ADR-011 |
+| Should a NuGet advisory fail the local build? | **Yes, accepted.** `TreatWarningsAsErrors` elevates `NU1903`, delivering `R-04`'s vulnerability gate earlier. Escape hatch recorded in ADR-010 if it becomes obstructive. | ADR-010 |
+| `RecipeManager.Api.csproj.user` committed | **Untracked**, and `*.user` added to `.gitignore` — it carried one developer's debug profile. Fixed 2026-08-04. | — |

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -3,7 +3,8 @@
 Every **defect and gap in what already exists**. Planned work that does not exist yet lives in
 [roadmap.md](roadmap.md); the two files cross-reference each other.
 
-Verified against `main` @ `edfd057` on 2026-07-26 by running the real toolchain — not by reading code.
+Verified against `main` @ `edfd057` on 2026-07-26 by running the real toolchain — not by reading code. Build and
+test numbers re-measured on 2026-08-04 after `R-02`.
 
 > **Rules for agents**
 > - Do not leave inline TODO markers scattered in the docs or the code. Add an entry here instead.
@@ -19,7 +20,7 @@ Verified against `main` @ `edfd057` on 2026-07-26 by running the real toolchain 
 
 | Check | Command | Result |
 | --- | --- | --- |
-| Backend build | `dotnet build RecipeManager.sln` | 0 errors, **7 warnings** — all in `RecipeManager.UnitTests` |
+| Backend build | `dotnet build RecipeManager.sln` | 0 errors, **0 warnings** — enforced by `TreatWarningsAsErrors` (ADR-010) |
 | Backend tests | `dotnet test RecipeManager.sln` | **84 passing** (70 unit + 14 integration), 0 failing |
 | NuGet vulnerabilities | `dotnet list package --vulnerable --include-transitive` | **none**, all six projects clean |
 | Frontend type-check | `npx tsc --noEmit` | **0 errors** |
@@ -28,9 +29,13 @@ Verified against `main` @ `edfd057` on 2026-07-26 by running the real toolchain 
 | npm vulnerabilities | `npm audit` · Dependabot API | **17 packages** (12 high) · **68 open alerts** — 32 high, 32 medium, 4 low ([SEC-03](#sec-03)) |
 | Frontend tests | — | **none exist**, no runner installed ([TEST-01](#test-01)) |
 
-**Goal: zero warnings across every project.** The seven backend warnings ([BUILD-01](#build-01),
-[BUILD-02](#build-02)) are all in test code, all trivially fixable, and all introduced by the package upgrades
-in the .NET 10 migration — they were not present on the .NET 8 package set.
+**Zero warnings across every backend project, enforced.** `RecipeManager/Directory.Build.props` sets
+`TreatWarningsAsErrors`, so a warning is a build failure rather than a note somebody may or may not read
+(ADR-010, `R-02`). The seven warnings that existed until then — introduced by the .NET 10 package upgrades, not
+present on the .NET 8 set — were `BUILD-01` and `BUILD-02`, both fixed in the same PR.
+
+The frontend has no equivalent gate: `npm run lint` still cannot start ([BUILD-03](#build-03)) and
+`npm run build` still does not type-check ([BUILD-04](#build-04)).
 
 ---
 
@@ -38,8 +43,6 @@ in the .NET 10 migration — they were not present on the .NET 8 package set.
 
 | ID | Severity | Area | Issue |
 | --- | --- | --- | --- |
-| [BUILD-01](#build-01) | Medium | Build | 5× `CS8602` in unit tests — NSubstitute 6 nullable `Arg.Is<T>` |
-| [BUILD-02](#build-02) | Medium | Build | 2× `xUnit1012` — `[InlineData(null)]` on a non-nullable `string` |
 | [BUILD-03](#build-03) | **High** | Tooling | `npm run lint` cannot run — `jiti` missing from `devDependencies` |
 | [BUILD-04](#build-04) | **High** | Tooling | `npm run build` does not type-check |
 | [BUILD-05](#build-05) | Medium | Perf | `mainPhoto.png` is 2.1 MB — 5.7× the entire JS bundle |
@@ -95,48 +98,6 @@ Resolved decisions and items promoted to planned work are recorded in [Settled](
 ---
 
 ## Build & tooling
-
-### BUILD-01
-**5× `CS8602: Dereference of a possibly null reference` — Medium**
-
-| File | Line |
-| --- | --- |
-| `RecipeManager.UnitTests/Application/Handlers/CreateRecipeHandlerTests.cs` | 55 |
-| `RecipeManager.UnitTests/Application/Handlers/DeleteRecipeHandlerTests.cs` | 56 |
-| `RecipeManager.UnitTests/Application/Handlers/UpdateRecipeHandlerTest.cs` | 63, 233, 275 |
-
-**Cause.** All five are `Arg.Is<Recipe>(r => r.Title == …)` inside a `Received(1)` assertion. NSubstitute 6.0
-annotates the `Arg.Is<T>` predicate parameter as nullable, so `r` is `Recipe?` and every member access warns.
-Introduced by the NSubstitute 5.3 → 6.0 upgrade in the .NET 10 migration.
-
-**Fix.** Guard inside the predicate — this also makes the assertion honest:
-```csharp
-Arg.Is<Recipe>(r => r != null && r.Title == command.Title)
-```
-Do **not** silence it with `r!` or `#pragma warning disable`.
-
-**Owner:** `02-senior-csharp` · **Effort:** ~15 min
-
-### BUILD-02
-**2× `xUnit1012: Null should not be used for type parameter` — Medium**
-
-`RecipeManager.UnitTests/Domain/Entities/RecipeTests.cs:76` (`invalidTitle`) and `:96` (`invalidDescription`).
-
-**Cause.** `[InlineData(null)]` on a `[Theory]` whose parameter is a non-nullable `string`. The test is
-deliberately exercising the null case — the signature is what is wrong.
-
-**Fix.** Widen the parameter and pass it through:
-```csharp
-[Theory]
-[InlineData(null)]
-[InlineData("")]
-[InlineData("   ")]
-public void Create_WithInvalidTitle_ShouldReturnFailureResult(string? invalidTitle)
-```
-`Recipe.Create` already takes a non-nullable `string`, so the call site needs `invalidTitle!` — which is
-correct here, since passing null *is* the scenario under test.
-
-**Owner:** `02-senior-csharp` · **Effort:** ~10 min
 
 ### BUILD-03
 **`npm run lint` cannot run on a clean install — High**
@@ -512,8 +473,8 @@ No `.github/` directory, no workflow, nothing. Every check in
 [workflows/release-workflow.md](workflows/release-workflow.md) is manual and therefore skippable —
 [BUILD-03](#build-03) is direct evidence that an unenforced check silently rots.
 
-**Minimum useful pipeline:** `dotnet build` (warnings as errors once [BUILD-01](#build-01)/[BUILD-02](#build-02)
-are fixed), `dotnet test`, `npm ci`, `npm run typecheck`, `npm run lint`, `npm run build`. Add
+**Minimum useful pipeline:** `dotnet build` (already warnings-as-errors via `Directory.Build.props`, ADR-010),
+`dotnet test`, `npm ci`, `npm run typecheck`, `npm run lint`, `npm run build`. Add
 `dotnet list package --vulnerable` and `npm audit` so [SEC-03](#sec-03) cannot silently regrow. Dependabot
 *alerting* is already enabled and currently reports 68 open alerts, but nothing acts on it — enabling Dependabot
 **pull requests** and failing CI on high-severity alerts is what turns it from a notification into a control.
@@ -674,3 +635,5 @@ Decisions that were open and are now answered, kept so they are not re-litigated
 | Ingredients: keep free text or structure them? | **Structure them.** The `string[]` shape was an acknowledged temporary shortcut. | `R-10` |
 | CQRS: hand-rolled or MediatR? | **Keep hand-rolled**, and remove its one real drawback by auto-registering handlers with Scrutor (already a dependency). **Shipped 2026-08-03.** | ADR-001, ADR-008 |
 | Integration tests: EF InMemory or a real database? | **Testcontainers with real PostgreSQL**, deferred until CI exists. | `R-06` |
+| `BUILD-01`, `BUILD-02` — 7 backend build warnings | **Fixed**, and made unrepeatable by `TreatWarningsAsErrors` in `Directory.Build.props`. **Shipped 2026-08-04.** | ADR-010 |
+| Should warnings-as-errors be Release-only? | **No — every configuration.** There is no CI yet (`INFRA-01`), so a Release-only condition would enforce nothing. | ADR-010 |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -60,6 +60,13 @@ Dependabot **alerting** is already on (68 open alerts today) but nothing acts on
 **pull requests** for both ecosystems and fail the build on high-severity alerts — that is what turns a
 notification into a gate. Closes `INFRA-01` and stops `SEC-03` from silently regrowing.
 
+**Decide NuGet lock files here, not before.** The frontend restores from a committed `package-lock.json`; the
+backend has no equivalent, so the transitive graph is resolved fresh on every restore and CI could legitimately
+get a different closure than a developer did. `<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>`
+in `Directory.Build.props` plus committed `packages.lock.json` files fixes that, and `--locked-mode` in CI makes
+an unexpected change fail rather than pass silently. It is deliberately deferred to this item because a lock
+file only earns its maintenance cost once something reproducible consumes it.
+
 Also closes `INFRA-06`: on a Windows machine with Smart App Control enabled the 14 integration tests cannot load
 the freshly built `RecipeManager.Api.dll` at all, so they are unreliable locally right after a backend change. A
 Linux runner has no such policy, which makes CI the **only** trustworthy place to run them until then.
@@ -134,6 +141,29 @@ Nothing detects contract drift, which is exactly how `BUG-01`–`BUG-05` accumul
 Add an `openapi-typescript` step producing a generated, committed types file, with a CI check that fails when
 the generated output differs from what is committed. Fix `BUG-01`–`BUG-05` first (they are defects, not
 roadmap), then make recurrence impossible.
+
+### R-15
+**Adopt an `.editorconfig`, or drop `EnforceCodeStyleInBuild`** · `01-architect` → `02-senior-csharp` · ~2 h
+
+`Directory.Build.props` sets `EnforceCodeStyleInBuild` (ADR-010), but there is no `.editorconfig` anywhere in
+the repo, so IDE style rules sit at their default suggestion severity and **nothing is currently enforced**. The
+property is a latch, not a control: it does nothing until an `.editorconfig` exists, and then it does a great
+deal at once.
+
+That is the whole difficulty. With `TreatWarningsAsErrors` also on, any rule set to `warning` becomes a **build
+error in every file simultaneously**. This is the same shape as `UX-02` — a change that shifts every existing
+file and must therefore be one deliberate pass, never a side effect of another PR.
+
+**Decide in this order:**
+
+1. Which rule families are wanted (`IDE0055` formatting, `IDE0005` unused usings, naming rules, `var` preference)
+   — the repo's existing style is the reference, not a blog post's.
+2. What severity each gets. `suggestion` enforces nothing; `warning` is a build break under ADR-010. Starting
+   everything at `suggestion` and promoting deliberately is the low-risk path.
+3. Whether the one-off reformat lands as its own commit, so review can separate it from behaviour changes.
+
+Ending with "we do not want this" is a legitimate outcome — then **delete `EnforceCodeStyleInBuild`**, because a
+property that enforces nothing while looking like a gate is worse than no property at all.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,27 +32,6 @@ that are *wrong* with what already exists.
 
 These are cheap, unblock everything else, and each one removes a whole class of future bug.
 
-### R-02
-**Treat warnings as errors, centralise project properties** · `02-senior-csharp` · ~1 h
-
-`TargetFramework`, `Nullable`, and `ImplicitUsings` are duplicated across all six `.csproj` files, and nothing
-prevents a warning from being committed. Add `RecipeManager/Directory.Build.props`:
-
-```xml
-<Project>
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-  </PropertyGroup>
-</Project>
-```
-
-**Blocked by** `BUILD-01` and `BUILD-02` in [known-issues.md](known-issues.md) — fix those 7 warnings first,
-then turn this on so they can never come back.
-
 ### R-03
 **Fix the frontend toolchain** · `03-senior-react` · ~30 min
 
@@ -72,7 +51,7 @@ Nothing enforces any checklist today. `BUILD-03` is the proof: a check that nobo
 Minimum GitHub Actions workflow on every PR:
 
 ```
-dotnet build (warnings as errors after R-02) · dotnet test
+dotnet build (already warnings-as-errors, ADR-010) · dotnet test
 npm ci · npm run typecheck · npm run lint · npm run build
 dotnet list package --vulnerable --include-transitive · npm audit
 ```

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -1,6 +1,8 @@
 # Tech stack
 
-Versions read from `*.csproj`, `global.json`, and `recipe-manager-frontend/package.json` on `main` @ `edfd057`.
+Backend versions are all declared in `RecipeManager/Directory.Packages.props` (central package management,
+ADR-011) — that file is the single source of truth, not the `.csproj` files. SDK from `global.json`, frontend
+from `recipe-manager-frontend/package.json`.
 
 ## Runtimes
 

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -6,7 +6,7 @@ Versions read from `*.csproj`, `global.json`, and `recipe-manager-frontend/packa
 
 | Runtime | Version | Pinned in |
 | --- | --- | --- |
-| .NET | `net10.0` (all six projects) | each `.csproj` `<TargetFramework>` |
+| .NET | `net10.0` (all six projects) | `Directory.Build.props` `<TargetFramework>` (ADR-010) |
 | .NET SDK | `10.0.302`, `rollForward: latestFeature` | `RecipeManager/global.json` |
 | Node.js | not pinned | no `engines` field, no `.nvmrc` |
 | PostgreSQL | 16+ recommended by `README.md` | not enforced anywhere |

--- a/docs/workflows/bugfix-workflow.md
+++ b/docs/workflows/bugfix-workflow.md
@@ -74,8 +74,8 @@ Escalate when the fix requires: a schema/migration change, a new project referen
 
 ## 5. Regression sweep — `06-qa-tester`
 
-- The new test passes; the whole suite still passes (currently 84 tests) and no new build warning appeared
-  (currently 7, target 0 — see [../known-issues.md](../known-issues.md)).
+- The new test passes and the whole suite still passes (currently 84 tests). A new build warning cannot slip
+  through — it fails the build (ADR-010).
 - If the bug was a cache issue, add a test that performs write-then-read through the API — the integration tests
   exercise the real decorator chain.
 - If the bug involved concurrency or ordering, state explicitly in the PR that it is not covered; there is no

--- a/docs/workflows/feature-workflow.md
+++ b/docs/workflows/feature-workflow.md
@@ -105,8 +105,7 @@ Only if persistence changes.
   interaction (`Received(1)`).
 - Integration test in `RecipesControllerTests` for each new endpoint: status code + database state, with
   `DbContext.ChangeTracker.Clear()` before asserting after a write.
-- Run and compare against the current numbers — 84 passing, 7 build warnings (target 0, see
-  [../known-issues.md](../known-issues.md)):
+- Run and compare against the current numbers — 84 passing, 0 build warnings (warnings are errors, ADR-010):
   ```bash
   dotnet test RecipeManager.sln
   ```

--- a/docs/workflows/release-workflow.md
+++ b/docs/workflows/release-workflow.md
@@ -56,9 +56,8 @@ Run from `RecipeManager/`. Everything here is manual — nothing enforces it.
    ```bash
    dotnet build RecipeManager.sln
    ```
-   **Zero warnings is the standard.** Currently 7, all in `RecipeManager.UnitTests` (5× `CS8602`,
-   2× `xUnit1012`) — tracked as `BUILD-01`/`BUILD-02` in [../known-issues.md](../known-issues.md), not accepted
-   as a baseline. A *new* warning blocks the merge.
+   **Zero warnings, and it is enforced** — `TreatWarningsAsErrors` in `Directory.Build.props` (ADR-010) means a
+   new warning fails the build outright, so this step cannot be passed while one exists.
 
 2. **All tests pass.**
    ```bash
@@ -111,8 +110,8 @@ None | <MigrationName> — describe the schema change and whether it is destruct
 None | RecipeDto changed: <fields> — frontend updated in this PR (08-api-contract)
 
 ## Verification
-- dotnet build: <N> warnings (currently 7, target 0)
-- dotnet test: <N>/<N> passing (currently 78)
+- dotnet build: <N> warnings (must be 0 — warnings are errors)
+- dotnet test: <N>/<N> passing (currently 84)
 - npm run build + npx tsc --noEmit: pass | n/a
 - Manual check against a real PostgreSQL: <what you did> | n/a
 


### PR DESCRIPTION
## Problem

Seven build warnings had sat in `RecipeManager.UnitTests` since the .NET 10 upgrade (`BUILD-01`, `BUILD-02`).
Each was a two-minute fix, and they survived several PRs anyway — a warning is a line of scrollback between
"Build succeeded" and the prompt, and the number of those anyone reads is zero. Nothing prevented an eighth.

The same duplication problem existed twice over in the project files: `TargetFramework`, `Nullable`, and
`ImplicitUsings` copy-pasted into all six `.csproj` files, and ten package **versions** declared in two projects
each. The second is the worse failure, because it has no diagnostic at all — bump EF Core in `Infrastructure`
and not `Api`, and NuGet resolves nearest-wins silently, surfacing at runtime in whichever project lost.

## Change

* The 7 warnings fixed as `known-issues.md` prescribed, not suppressed. Five `CS8602` become a null-guard inside
the NSubstitute predicate — `Arg.Is<Recipe>(r => r != null && r.Title == …)`, which also makes the assertion
honest, since a null `Recipe` previously threw inside the matcher rather than failing the test. Two `xUnit1012`
become a widened `string?` theory parameter with `invalidTitle!` at the call site: `!` is correct there and only
there, because passing null *is* the case under test.
* New `RecipeManager/Directory.Build.props` owns `TargetFramework`, `Nullable`, `ImplicitUsings`,
`TreatWarningsAsErrors`, `EnforceCodeStyleInBuild`; all six `.csproj` files lose their copies and keep only what
is genuinely theirs. `TreatWarningsAsErrors` is **unconditional, not Release-only** — the usual advice assumes a
CI that runs Release, and there isn't one yet (`INFRA-01`, `R-04`), so a Release-only condition would enforce
nothing while looking like a control. ADR-010.
* `EnforceCodeStyleInBuild` is on but currently reports nothing: IDE style rules default to suggestion severity
and there is no `.editorconfig`. It is a latch, not a gate, and arming it is filed as `R-15` — with
`TreatWarningsAsErrors` on, any rule at `warning` severity breaks every file at once, so it cannot be
incidental to another PR.
* New `RecipeManager/Directory.Packages.props` sets `ManagePackageVersionsCentrally` and holds all 21 versions.
`.csproj` files carry bare `<PackageReference Include="…" />` with per-project `PrivateAssets`/`IncludeAssets`
only. Version drift becomes unrepresentable rather than discouraged. ADR-011.
* `*.user` added to `.gitignore` and `RecipeManager.Api.csproj.user` untracked — it carried
`ActiveDebugProfile = Container (Dockerfile)`, so every clone inherited one developer's F5 target. The Rider
pattern (`*.DotSettings.user`) was already ignored; the Visual Studio one never was.
* Docs updated: ADR-010 and ADR-011 added, `R-02` removed from the roadmap, `BUILD-01`/`BUILD-02` deleted from
`known-issues.md`, and the "currently 7 warnings, target 0" baseline inverted across `CLAUDE.md`,
`conventions.md`, `tech-stack.md`, all three workflows, and the `00`/`02`/`04`/`06` agent checklists — a warning
is now a build failure, not a review finding. `conventions.md` also gains the two NSubstitute/xUnit idioms as
rules, and the package-version rule, so neither is rediscovered.

## Verification

`dotnet build` after `dotnet clean`: **0 errors, 0 warnings** (was 7). `dotnet test`: **84/84 passing**,
unchanged. No frontend file touched, no migration, no contract change.

Both gates were verified by deliberately breaking them — a gate never seen to reject anything is
indistinguishable from no gate, which is precisely what `BUILD-03` turned out to be:

| Probe | Result |
| --- | --- |
| Unused local added to a Domain file | `error CS0219` — build fails |
| `Version=` put back on a `PackageReference` | `error NU1008` — build fails |
| Package with a published advisory (scratch project, outside the repo) | `error NU1903` — build fails |

The third is a live consequence worth flagging: `TreatWarningsAsErrors` is honoured by NuGet **restore**, not
just the compiler, and `NuGetAuditMode` defaults to `all` on .NET 10, so a newly published advisory against any
dependency — direct or transitive — will fail the build with no code change. Accepted deliberately rather than
exempted: it delivers `R-04`'s planned `dotnet list package --vulnerable` gate earlier and harder, and `SEC-03`
(68 npm alerts nobody acts on) is the failure it prevents on the .NET side. All six projects are clean today.
Escape hatch recorded in ADR-010 if it ever obstructs.

## Follow-ups

`R-15` (`.editorconfig`, or delete `EnforceCodeStyleInBuild` — both acceptable, the current state is not).
NuGet lock files folded into `R-04` rather than given an ID, since a lock file only earns its maintenance cost
once CI consumes it. `<Folder Include="Migrations\" />` in `RecipeManager.Infrastructure.csproj` is vestigial —
too small for an ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
