### PR TITLE
Make the frontend lint and type-check gates work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,9 +118,10 @@ Current state: build succeeds with **0 warnings** and **84 tests pass** (70 unit
 a **build failure**, not a note — and `TargetFramework`, `Nullable`, and `ImplicitUsings` live there too. Never
 re-declare those in a `.csproj`.
 
-Frontend checks are in worse shape than they look: `npm run lint` **cannot run at all** on a clean install, and
-`npm run build` does not type-check (`BUILD-03`, `BUILD-04`). Read those entries before trusting a green
-frontend build.
+Frontend checks work as of `R-03`/ADR-012: `npm run lint` runs and reports 0 problems, `npm run build` is
+`tsc -b && vite build` so a type error fails it, and `npm run typecheck` exists for the fast local loop. What
+they are not is *automatic* — nothing invokes them until CI lands (`INFRA-01`, `R-04`), so run all three from
+`RecipeManager/recipe-manager-frontend/` before opening a frontend PR.
 
 Unit-test coverage with an HTML report (needs `dotnet tool install --global dotnet-reportgenerator-globaltool`):
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,22 @@ fall back to the relative `/api` path, which `vite.config.ts` proxies to the sam
 
 Start the API first — the frontend has no mock backend.
 
+### Frontend checks
+
+Run these before opening a pull request; nothing runs them for you yet.
+
+```bash
+npm run lint
+```
+
+```bash
+npm run build
+```
+
+`npm run build` is `tsc -b && vite build`, so a type error fails it before Vite bundles anything. For a faster
+loop while working, `npm run typecheck` runs the same check without producing `dist/`. There is no `npm test` —
+no frontend test runner exists yet.
+
 ## Docker
 
 `RecipeManager.Api/Dockerfile` builds the API alone (no database container). Build from the `RecipeManager/`

--- a/RecipeManager/recipe-manager-frontend/.gitignore
+++ b/RecipeManager/recipe-manager-frontend/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# tsc -b incremental build state (`npm run build`)
+*.tsbuildinfo
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/RecipeManager/recipe-manager-frontend/eslint.config.ts
+++ b/RecipeManager/recipe-manager-frontend/eslint.config.ts
@@ -7,11 +7,14 @@ import tseslint from 'typescript-eslint'
 export default tseslint.config(
   { ignores: ['dist'] },
 
-  ...tseslint.configs.recommendedTypeChecked,
-  ...tseslint.configs.stylisticTypeChecked,
-
+  // Application source. tsconfig.json has `include: ["src"]`, so these are the only
+  // files type information is available for — the type-checked rule sets belong here.
   {
-    files: ['**/*.{ts,tsx}'],
+    files: ['src/**/*.{ts,tsx}'],
+    extends: [
+      ...tseslint.configs.recommendedTypeChecked,
+      ...tseslint.configs.stylisticTypeChecked,
+    ],
     languageOptions: {
       parser: tseslint.parser,
       parserOptions: {
@@ -32,11 +35,17 @@ export default tseslint.config(
 
       'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'no-console': ['error', { allow: ['warn', 'error'] }],
     },
   },
 
+  // Build tooling at the repo root. These run in Node and are outside tsconfig.json's
+  // `include`, so type-aware linting is impossible for them.
   {
-    files: ['**/*.{js,cjs,mjs}'],
-    ...tseslint.configs.disableTypeChecked,
+    files: ['*.{ts,mts,cts,js,mjs,cjs}'],
+    extends: [tseslint.configs.disableTypeChecked],
+    languageOptions: {
+      globals: globals.node,
+    },
   },
 )

--- a/RecipeManager/recipe-manager-frontend/package-lock.json
+++ b/RecipeManager/recipe-manager-frontend/package-lock.json
@@ -29,6 +29,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
+        "jiti": "^2.7.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.39.1",
@@ -3438,6 +3439,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4549,21 +4560,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/RecipeManager/recipe-manager-frontend/package.json
+++ b/RecipeManager/recipe-manager-frontend/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "tsc -b && vite build",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "preview": "vite preview"
   },
@@ -31,6 +32,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "jiti": "^2.7.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.39.1",

--- a/RecipeManager/recipe-manager-frontend/src/App.tsx
+++ b/RecipeManager/recipe-manager-frontend/src/App.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import { ThemeProvider } from '@/contexts/ThemeContext';
+import { ThemeProvider } from '@/contexts';
 import { HomePage, RecipePage } from '@/pages';
 import { AppLayout } from '@/components';
 

--- a/RecipeManager/recipe-manager-frontend/src/components/common/SearchBar/SearchBar.tsx
+++ b/RecipeManager/recipe-manager-frontend/src/components/common/SearchBar/SearchBar.tsx
@@ -15,8 +15,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
 
     const handleInputChange = (e:React.ChangeEvent<HTMLInputElement>) => {
         onSearchChange(e.target.value);
-        console.log(searchQuery);
-    } 
+    }
 
     return (
         <div className={styles.searchContainer}>

--- a/RecipeManager/recipe-manager-frontend/src/components/layout/Footer/Footer.tsx
+++ b/RecipeManager/recipe-manager-frontend/src/components/layout/Footer/Footer.tsx
@@ -1,11 +1,10 @@
-import { useContext } from "react";
 import styles from "./Footer.module.css";
-import { ThemeContext } from "@/contexts";
+import { useTheme } from "@/hooks";
 import SunnyIcon from '@mui/icons-material/Sunny';
 import DarkIcon from '@mui/icons-material/Bedtime';
 
 export const Footer: React.FC = () => {
-  const { theme, toggleTheme } = useContext(ThemeContext);
+  const { theme, toggleTheme } = useTheme();
   const nextTheme = theme === "light" ? "dark" : "light";
 
   return (

--- a/RecipeManager/recipe-manager-frontend/src/components/ui/Recipe/RecipeCard/RecipeCard.tsx
+++ b/RecipeManager/recipe-manager-frontend/src/components/ui/Recipe/RecipeCard/RecipeCard.tsx
@@ -11,7 +11,7 @@ interface RecipeCardProps {
 export const RecipeCard : React.FC<RecipeCardProps> = ({ recipe, onClick }) => {
 
     const formatDuration = (minutes: number): string => {
-        const safeMinutes = Math.max(0, Number.isFinite(minutes as number) ? (minutes as number) : 0);
+        const safeMinutes = Math.max(0, Number.isFinite(minutes) ? minutes : 0);
 
         if(safeMinutes < 60) return `${safeMinutes} min`;
 
@@ -22,7 +22,7 @@ export const RecipeCard : React.FC<RecipeCardProps> = ({ recipe, onClick }) => {
     }
 
     const getISODuration = (minutes: number): string => {
-        const safeMinutes = Math.max(0, Number.isFinite(minutes as number) ? (minutes as number) : 0);
+        const safeMinutes = Math.max(0, Number.isFinite(minutes) ? minutes : 0);
 
         if (safeMinutes < 60) return `PT${safeMinutes}M`;
 
@@ -49,7 +49,7 @@ export const RecipeCard : React.FC<RecipeCardProps> = ({ recipe, onClick }) => {
         <CardComponent className={`${styles.recipesList} ${onClick ? styles.clickable : ''}`} {...cardProps}> 
             <div className={styles.imageBox}>
                 <img
-                    src={recipe.image || Logo}
+                    src={recipe.image ?? Logo}
                     className={styles.heroImage}
                     alt={`${recipe.title} photo`}
                     loading="lazy"

--- a/RecipeManager/recipe-manager-frontend/src/components/ui/Recipe/RecipeList/RecipeList.tsx
+++ b/RecipeManager/recipe-manager-frontend/src/components/ui/Recipe/RecipeList/RecipeList.tsx
@@ -1,6 +1,5 @@
 // src/pages/RecipeList.tsx
 import React, { useMemo } from 'react';
-import type { Recipe } from '@/types';
 import { RecipeCard } from '@/components';
 import styles from './RecipeList.module.css';
 import { useRecipes } from '@/hooks/useRecipes';
@@ -35,10 +34,6 @@ export const RecipeList: React.FC<RecipeListProps> = ({searchQuery = ''}) => {
       return searchableText.includes(query);
     });
   }, [recipes, searchQuery])
-
-  const handleRecipeClick = (recipe: Recipe) => {
-    console.log('Clicked recipe:', recipe.title);
-  };
 
   if (loading) return <div className={styles.loadingSection}>Loading…</div>;
   if (error) {
@@ -85,7 +80,6 @@ export const RecipeList: React.FC<RecipeListProps> = ({searchQuery = ''}) => {
             <RecipeCard
               key={recipe.id}
               recipe={recipe}
-              onClick={handleRecipeClick}
             />
           ))}
         </>

--- a/RecipeManager/recipe-manager-frontend/src/contexts/ThemeContext.ts
+++ b/RecipeManager/recipe-manager-frontend/src/contexts/ThemeContext.ts
@@ -2,6 +2,4 @@
 import { ThemeContextType } from "@/types/theme";
 import { createContext } from "react";
 
-// No default value: `useTheme` throws when the context is undefined, which is what turns
-// "used outside ThemeProvider" from a silently wrong theme into a loud error.
 export const ThemeContext = createContext<ThemeContextType | undefined>(undefined);

--- a/RecipeManager/recipe-manager-frontend/src/contexts/ThemeContext.ts
+++ b/RecipeManager/recipe-manager-frontend/src/contexts/ThemeContext.ts
@@ -1,0 +1,7 @@
+// src/contexts/ThemeContext.ts
+import { ThemeContextType } from "@/types/theme";
+import { createContext } from "react";
+
+// No default value: `useTheme` throws when the context is undefined, which is what turns
+// "used outside ThemeProvider" from a silently wrong theme into a loud error.
+export const ThemeContext = createContext<ThemeContextType | undefined>(undefined);

--- a/RecipeManager/recipe-manager-frontend/src/contexts/ThemeProvider.tsx
+++ b/RecipeManager/recipe-manager-frontend/src/contexts/ThemeProvider.tsx
@@ -1,13 +1,8 @@
-import { ThemeContextType, Theme } from "@/types/theme";
+import { Theme } from "@/types/theme";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { ThemeContext } from "./ThemeContext";
 
-export const ThemeContext = React.createContext<ThemeContextType>({
-    theme: 'light',
-    toggleTheme: () => {},
-    setTheme: () => {}
-});
-
-export const ThemeProvider: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
+export const ThemeProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
     const isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined';
 
     const [theme, setTheme] = useState<Theme>(() => {
@@ -31,7 +26,7 @@ export const ThemeProvider: React.FC<React.PropsWithChildren<{}>> = ({ children 
             window.localStorage.setItem('theme', theme);
         } catch {
         }
-    }, [theme]);
+    }, [theme, isBrowser]);
 
     const toggleTheme = useCallback(() => {
         setTheme(prev => prev === 'light' ? 'dark' : 'light');

--- a/RecipeManager/recipe-manager-frontend/src/contexts/index.ts
+++ b/RecipeManager/recipe-manager-frontend/src/contexts/index.ts
@@ -1,3 +1,4 @@
 // src/contexts/index.ts
 
 export * from './ThemeContext';
+export * from './ThemeProvider';

--- a/RecipeManager/recipe-manager-frontend/src/main.tsx
+++ b/RecipeManager/recipe-manager-frontend/src/main.tsx
@@ -10,7 +10,7 @@ import './styles/globals.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
-const container = document.getElementById('root') as HTMLElement;
+const container = document.getElementById('root')!;
 const root = createRoot(container);
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/docs/agents/03-senior-react.md
+++ b/docs/agents/03-senior-react.md
@@ -108,15 +108,17 @@ There is **no form in the codebase today** and no form library installed. When b
 npm run build
 ```
 ```bash
-npx tsc --noEmit
+npm run lint
 ```
 
-- [ ] **`npm run build` does not type-check** (`BUILD-04`) — run `npx tsc --noEmit` separately until that is
-      fixed. It currently passes with 0 errors.
-- [ ] **`npm run lint` cannot run on a clean install** (`BUILD-03`) — `eslint.config.ts` needs `jiti`, which is
-      not a dependency. Do not report "lint passes" without checking that it actually executed.
-- [ ] No `console.log` added. Existing ones in `SearchBar.tsx` and `RecipeList.tsx` (`BUG-08`) should be removed
-      when you are next in those files.
+- [ ] `npm run build` runs `tsc -b` before Vite (ADR-012), so it type-checks. `npm run typecheck` is the same
+      check without bundling when you want a faster loop.
+- [ ] `npm run lint` must report **0 problems**. Read the output — an ESLint that cannot start also exits
+      non-zero, and for eleven months nobody noticed the difference (`BUILD-03`, now closed).
+- [ ] No `console.log` added — `no-console` is an **error** in the flat config (`warn`/`error` are allowed).
+- [ ] Type-aware rules only cover `src/**`. A new root-level `.ts` tooling file lands in the non-type-checked
+      block, and a new folder outside `src/` needs adding to `tsconfig.json`'s `include` before typed rules
+      apply to it.
 - [ ] Verified in **both** light and dark themes.
 - [ ] Anything left undone is an entry in [../known-issues.md](../known-issues.md), not a code comment.
 
@@ -131,7 +133,7 @@ npx tsc --noEmit
 
 1. Components/hooks/pages with barrels updated.
 2. CSS Modules using theme variables, verified light and dark.
-3. `npm run build` and `npx tsc --noEmit` output (not `npm run lint` — see `BUILD-03`).
+3. `npm run build` and `npm run lint` output.
 4. A note on which of the four states (loading/error/empty/populated) were implemented.
 5. New entries in [../known-issues.md](../known-issues.md) for anything you had to leave undone — never a
    inline TODO marker in the source or the docs.
@@ -148,7 +150,10 @@ npx tsc --noEmit
    - **Why this element**, when the choice carries accessibility meaning — `<button>` vs. `<div onClick>`,
      `<article>` vs. `<section>`, `<time dateTime>` vs. plain text.
    - **What TypeScript is and is not checking** — especially that `npm run build` strips types without checking
-     them (`BUILD-04`), so a green build proves less than it appears to.
+     them — which is why `npm run build` now runs `tsc -b` first (ADR-012). Note also that
+     `@typescript-eslint/no-unused-vars` is configured with `varsIgnorePattern: '^[A-Z_]'`, so it ignores every
+     PascalCase binding: an unused component or type import is caught by `tsc`'s `noUnusedLocals`, not by lint.
+     The two checks are not interchangeable.
 
 ## Handoff
 

--- a/docs/agents/04-code-reviewer.md
+++ b/docs/agents/04-code-reviewer.md
@@ -24,9 +24,9 @@ required — then security reviews after code review.
       it is a **Block** unless the PR states why the warning is wrong.
 - [ ] `dotnet test RecipeManager.sln` — **84 passing** is the current count. Fewer than before with no
       explanation is a Block.
-- [ ] Frontend touched ⇒ `npm run build` **and** `npx tsc --noEmit`. `npm run build` does not type-check
-      (`BUILD-04`), and `npm run lint` cannot run at all on a clean install (`BUILD-03`) — do not accept
-      "lint passes" as evidence until that is fixed.
+- [ ] Frontend touched ⇒ `npm run build` **and** `npm run lint`, both clean (ADR-012). A new
+      `eslint-disable` comment or a rule downgraded in `eslint.config.ts` to get past lint is a **Block** unless
+      the PR states why the rule is wrong here.
 - [ ] The author's claimed numbers match what you actually observed.
 - [ ] Anything the PR fixes from [../known-issues.md](../known-issues.md) has had its entry **deleted** in the
       same PR; anything it discovers has been **added** there.

--- a/docs/agents/06-qa-tester.md
+++ b/docs/agents/06-qa-tester.md
@@ -166,8 +166,9 @@ real gap in the suite: `TEST-02` in [../known-issues.md](../known-issues.md).
 There is no Vitest, no Jest, no React Testing Library, and no `test` script in `package.json`.
 
 **Decided stack: Vitest + React Testing Library + jsdom** (`R-07` in [../roadmap.md](../roadmap.md)) — the
-project is already Vite-based and Vitest reuses `vite.config.ts` aliases directly. Blocked by `R-03`, since the
-frontend toolchain itself is broken.
+project is already Vite-based and Vitest reuses `vite.config.ts` aliases directly. **Unblocked** — `R-03`
+shipped the working toolchain on 2026-08-08 (ADR-012). Note that Vitest's own config file will land outside
+`tsconfig.json`'s `include`, so check which ESLint block picks it up.
 
 First tests worth writing, in priority order:
 
@@ -176,8 +177,9 @@ First tests worth writing, in priority order:
 2. `RecipeList` filtering — matches on title, description, and ingredients; case-insensitive; trims;
    empty-query returns everything.
 3. `RecipeList` states — loading, error, empty-with-query vs. empty-without-query, populated.
-4. `ThemeContext` / `useTheme` — persists to `localStorage`, sets `data-theme` on `<html>`, and the guard hook
-   throws outside a provider.
+4. `ThemeProvider` / `useTheme` — persists to `localStorage`, sets `data-theme` on `<html>`, and the guard hook
+   throws outside a provider. That last case only became testable in `R-03`: the context previously had a
+   default value, so `useContext` never returned `undefined` and the guard could not fire.
 5. `NavLink` active-state logic — trailing-slash normalisation and prefix matching (`/recipes` active on
    `/recipes/123`).
 

--- a/docs/agents/08-api-contract.md
+++ b/docs/agents/08-api-contract.md
@@ -105,8 +105,9 @@ prerequisite for any recipe detail or edit screen.
 
 - [ ] Compare against the running Swagger document rather than reading the C# by eye:
       `dotnet run --project RecipeManager.Api --launch-profile https` then `https://localhost:7231/swagger`.
-- [ ] `npx tsc --noEmit` — **not** `npm run build`, which strips types without checking them (`BUILD-04`).
-      Type-checking is the only automated signal on this seam, and it is not currently wired into any script.
+- [ ] `npm run typecheck`, and `npm run build` (which now type-checks too — ADR-012). Type-checking is the only
+      automated signal on this seam, so treat a green `tsc` as *necessary but not sufficient*: it proves the TS
+      code agrees with the TS types, never that the TS types agree with `RecipeDto`.
 - [ ] Manually exercise the changed endpoint from the SPA, or with the Swagger UI, and confirm the payload
       matches the TS type.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -322,6 +322,31 @@ endpoint is anonymous and every recipe is world-writable. See
   it cannot stop a new class of warning. *(c)* Fixing the seven warnings without the gate — leaves the count
   free to grow back, which is the `BUILD-03` failure mode.
 
+### ADR-012 — The frontend gets a build gate: `jiti` and a type-checking build
+
+- **Status:** accepted and **implemented 2026-08-08** (`R-03`).
+- **Context:** ADR-010 made every backend warning a build failure, but stops at the solution boundary. On the
+  frontend `npm run lint` could not *start* — `eslint.config.ts` is a TypeScript flat config and ESLint 9 loads
+  those through `jiti`, which was never a dependency (`BUILD-03`, since commit `3474a8b`, 2025-08-08) — and
+  `"build": "vite build"` transpiles with esbuild, which strips types without checking them (`BUILD-04`). So no
+  ESLint rule and no type error could fail anything for eleven months.
+- **Decision:** add `jiti` to `devDependencies`; make `"build": "tsc -b && vite build"` and add
+  `"typecheck": "tsc --noEmit"`. Scope the type-checked ESLint rule sets to the files `tsconfig.json` actually
+  includes, and lint the root config files with a non-type-checked config instead.
+- **Alternatives:** *(a)* rename the config to `eslint.config.js` — no new dependency, but it discards type
+  checking of the config and the typed `tseslint.config()` helper the project already uses. *(b)*
+  `tsc --noEmit && vite build` — one fewer TS mode to understand, but not incremental; `tsc -b` is the Vite
+  React-TS template default and both are valid against a single non-composite `tsconfig.json`. *(c)* leave it
+  and rely on `R-04`'s CI to run `npx tsc` directly — but CI cannot run a script that does not exist, and the
+  local loop would still have no gate.
+- **Consequences:** the frontend now has the enforcement ADR-010 gave the backend, so `R-04` has something to
+  call and `R-07` (Vitest) has a working toolchain to attach to. The cost is real and daily: every frontend PR
+  must satisfy `recommendedTypeChecked` + `stylisticTypeChecked`, and a build that used to succeed with a type
+  error now fails. Verified by negative test in both directions — a deliberate type error fails `npm run build`,
+  and a deliberate `console.log` is reported by `npm run lint`. Note what is **not** bought: nothing forces
+  anyone to run either command until CI exists (`INFRA-01`, `R-04`). This makes the gate possible, not
+  automatic.
+
 ---
 
 These ADRs were **reconstructed from code and commit messages** — no ADR files existed before, so ADR-001

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -153,7 +153,7 @@ recipe-manager-frontend/src/
     common/    cross-cutting widgets (SearchBar)
     layout/    AppLayout, Header, Footer
     ui/        presentational pieces (Logo, NavLink, Recipe/RecipeCard, Recipe/RecipeList)
-  contexts/    ThemeContext
+  contexts/    ThemeContext (the context object), ThemeProvider (the component)
   hooks/       useTheme, useRecipes
   pages/       Home/HomePage, Recipe/RecipePage
   services/    recipeService (axios)
@@ -200,7 +200,14 @@ adding/updating its `index.ts`.
   invalidation leaves permanently stale data on screen. No mutation hook exists yet; the first one sets the
   precedent.
 - Consumers of a context must go through a guard hook that throws when the provider is missing — copy the
-  `useTheme` pattern.
+  `useTheme` pattern. Never call `useContext(SomeContext)` directly in a component; `Footer` did until `R-03`,
+  which is how it went unnoticed that the guard could not fire.
+- **A context created for a guard hook takes no default value** — `createContext<T | undefined>(undefined)`.
+  A "sensible" default makes `useContext` always return something, so the guard's `throw` is unreachable and a
+  component rendered outside its provider silently gets the default instead of a loud error.
+- The context object and the provider component live in **separate files** (`ThemeContext.ts` /
+  `ThemeProvider.tsx`). `react-refresh/only-export-components` enforces this: a module exporting both a
+  component and a non-component breaks Fast Refresh, so an edit forces a full reload instead of preserving state.
 
 ### API access
 
@@ -225,9 +232,9 @@ on images.
 
 ### Avoid
 
-- `console.log` in committed code. `SearchBar.handleInputChange` and `RecipeList.handleRecipeClick` still have
-  some (`BUG-08` in [known-issues.md](known-issues.md)) — do not add more. Note that ESLint would normally catch
-  this but currently cannot run at all (`BUILD-03`).
+- `console.log` in committed code — `no-console` is an **error** in `eslint.config.ts`, with `console.warn` and
+  `console.error` allowed. The rule was added in `R-03`: it had never been configured, so the eleven months of
+  unrunnable lint were not even the reason `BUG-08` survived.
 - Inline styles.
 - Declaring a path alias in only one of `vite.config.ts` / `tsconfig.json`.
 

--- a/docs/decisions-log.md
+++ b/docs/decisions-log.md
@@ -42,12 +42,62 @@ Jump to every entry touching a topic.
 | Domain modelling | [2026-07-26 Structured ingredients](#2026-07-26--free-text-ingredients-are-a-shortcut-with-an-expiry-date) |
 | Testing | [2026-07-26 Testcontainers](#2026-07-26--ef-inmemory-is-not-a-database), [2025-10-08 Integration tests](#2025-10-08--integration-tests-need-an-escape-hatch-and-escape-hatches-need-guards) |
 | Project direction | [2026-07-26 Project stance](#2026-07-26--practice-project-with-deployment-intent) |
-| Tooling / infrastructure | [2026-08-04 Warnings as errors](#2026-08-04--a-warning-nobody-has-to-fix-is-a-warning-that-multiplies), [2026-07-25 .NET 10 + PostgreSQL](#2026-07-25--net-10-and-postgresql) |
-| Enforcement vs. convention | [2026-08-04 Warnings as errors](#2026-08-04--a-warning-nobody-has-to-fix-is-a-warning-that-multiplies), [2026-07-26 Scrutor](#2026-07-26--auto-register-handlers-instead-of-listing-them), [2025-10-08 Integration tests](#2025-10-08--integration-tests-need-an-escape-hatch-and-escape-hatches-need-guards) |
+| Tooling / infrastructure | [2026-08-08 Frontend gate](#2026-08-08--a-check-that-cannot-start-and-a-check-that-passes-look-identical), [2026-08-04 Warnings as errors](#2026-08-04--a-warning-nobody-has-to-fix-is-a-warning-that-multiplies), [2026-07-25 .NET 10 + PostgreSQL](#2026-07-25--net-10-and-postgresql) |
+| Enforcement vs. convention | [2026-08-08 Frontend gate](#2026-08-08--a-check-that-cannot-start-and-a-check-that-passes-look-identical), [2026-08-04 Warnings as errors](#2026-08-04--a-warning-nobody-has-to-fix-is-a-warning-that-multiplies), [2026-07-26 Scrutor](#2026-07-26--auto-register-handlers-instead-of-listing-them), [2025-10-08 Integration tests](#2025-10-08--integration-tests-need-an-escape-hatch-and-escape-hatches-need-guards) |
+| Frontend / React | [2026-08-08 Frontend gate](#2026-08-08--a-check-that-cannot-start-and-a-check-that-passes-look-identical) |
+| Accessibility | [2026-08-08 Frontend gate](#2026-08-08--a-check-that-cannot-start-and-a-check-that-passes-look-identical) |
 
 ---
 
 ## Entries
+
+### 2026-08-08 — A check that cannot start and a check that passes look identical
+
+**Context.** `R-03`. `npm run lint` had been unable to *start* since 2025-08-08: the config was renamed to
+`eslint.config.ts` and ESLint 9 loads a TypeScript flat config through `jiti`, which was never added
+(`BUILD-03`). `npm run build` was `vite build`, and esbuild strips types without checking them (`BUILD-04`). So
+the frontend had two scripts that looked like gates and were not.
+
+**Decision.** Add `jiti`; `"build": "tsc -b && vite build"`; add `"typecheck"`. Scope the type-aware ESLint
+rule sets to `src/**` — the only files `tsconfig.json` includes — and lint the root tooling configs without type
+information. ADR-012.
+
+**Rejected.** *(a)* Renaming the config to `.js`: no new dependency, but it discards type checking of the config
+and the typed `tseslint.config()` helper already in use — reversing a 2025 decision to avoid a dev-only loader
+that never ships to a browser. *(b)* Merging the gate PR green and fixing the lint findings later: smaller diff,
+but a gate merged red is not a gate. *(c)* `ts-node`, which was already installed and is presumably a previous
+attempt at this fix — factually the wrong loader, and it sat there for a year looking like the problem was
+handled.
+
+**Cost.** Every frontend PR now has to satisfy `recommendedTypeChecked` + `stylisticTypeChecked`, and a build
+that used to succeed with a type error now fails. Same shape of friction as ADR-010, and the same answer: the
+friction is the mechanism.
+
+**What turning it on actually found.** Twelve errors, and the interesting ones were not style:
+
+- `ThemeContext` was created with a **default value**, so `useContext` never returned `undefined` and
+  `useTheme`'s `if (!ctx) throw` was unreachable code. The guard-hook pattern this repo documents as one of its
+  examples had never worked. `Footer` also called `useContext(ThemeContext)` directly, bypassing the hook —
+  which is why nobody hit the missing-provider case that would have exposed it.
+- `no-console` was **never configured**. `BUG-08` was recorded as "ESLint would have caught this had it been
+  runnable"; it would not have. The unrunnable linter was hiding a second gap, not causing this one.
+- `RecipeList` passed an `onClick` whose whole body was a `console.log`, so every card rendered as
+  `<button aria-label="View X recipe">` that did nothing when activated. Deleting the log left a no-op handler
+  and made the accessibility lie visible. Cards are now `<article>`; `BUG-10` tracks the missing detail route.
+- The unused `Recipe` import that appeared after that deletion was caught by **`tsc`, not ESLint** —
+  `no-unused-vars` is configured with `varsIgnorePattern: '^[A-Z_]'`, which exempts every PascalCase binding.
+  Two gates, genuinely different coverage.
+
+**Verified by negative test**, per the 2026-08-04 entry: a deliberate `const x: number = "s"` fails
+`npm run build` before Vite runs, and a deliberate `console.log` is reported by `npm run lint`.
+
+**Takeaway.** *An unrun check and a passing check are indistinguishable from outside — and the moment you can
+finally see through the window, expect the room to be dirtier than the ticket said.* The estimate for this was
+30 minutes for three one-line edits. What it actually surfaced was a documented pattern that had never
+functioned, a rule everyone assumed existed, and an accessibility defect hiding inside a debug statement. Budget
+for that: the value of turning on a disabled check is mostly in what it reports, not in the switch.
+
+---
 
 ### 2026-08-04 — A warning nobody has to fix is a warning that multiplies
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -4,7 +4,7 @@ Every **defect and gap in what already exists**. Planned work that does not exis
 [roadmap.md](roadmap.md); the two files cross-reference each other.
 
 Verified against `main` @ `edfd057` on 2026-07-26 by running the real toolchain — not by reading code. Build and
-test numbers re-measured on 2026-08-04 after `R-02`.
+test numbers re-measured on 2026-08-04 after `R-02`, and the frontend row re-measured on 2026-08-08 after `R-03`.
 
 > **Rules for agents**
 > - Do not leave inline TODO markers scattered in the docs or the code. Add an entry here instead.
@@ -23,10 +23,10 @@ test numbers re-measured on 2026-08-04 after `R-02`.
 | Backend build | `dotnet build RecipeManager.sln` | 0 errors, **0 warnings** — enforced by `TreatWarningsAsErrors` (ADR-010) |
 | Backend tests | `dotnet test RecipeManager.sln` | **84 passing** (70 unit + 14 integration), 0 failing |
 | NuGet vulnerabilities | `dotnet list package --vulnerable --include-transitive` | **none**, all six projects clean |
-| Frontend type-check | `npx tsc --noEmit` | **0 errors** |
-| Frontend build | `npm run build` | succeeds — but does **not** type-check ([BUILD-04](#build-04)) |
-| Frontend lint | `npm run lint` | **fails to start** on a clean install ([BUILD-03](#build-03)) |
-| npm vulnerabilities | `npm audit` · Dependabot API | **17 packages** (12 high) · **68 open alerts** — 32 high, 32 medium, 4 low ([SEC-03](#sec-03)) |
+| Frontend type-check | `npm run typecheck` | **0 errors** |
+| Frontend build | `npm run build` | succeeds, and now type-checks first (`tsc -b && vite build`, ADR-012) |
+| Frontend lint | `npm run lint` | **0 problems** — runs since `jiti` was added (ADR-012, `R-03`) |
+| npm vulnerabilities | `npm audit` · Dependabot API | **18 packages** (13 high, 3 moderate, 2 low) · **68 open alerts** — 32 high, 32 medium, 4 low ([SEC-03](#sec-03)) |
 | Frontend tests | — | **none exist**, no runner installed ([TEST-01](#test-01)) |
 
 **Zero warnings across every backend project, enforced.** `RecipeManager/Directory.Build.props` sets
@@ -34,8 +34,11 @@ test numbers re-measured on 2026-08-04 after `R-02`.
 (ADR-010, `R-02`). The seven warnings that existed until then — introduced by the .NET 10 package upgrades, not
 present on the .NET 8 set — were `BUILD-01` and `BUILD-02`, both fixed in the same PR.
 
-The frontend has no equivalent gate: `npm run lint` still cannot start ([BUILD-03](#build-03)) and
-`npm run build` still does not type-check ([BUILD-04](#build-04)).
+**The frontend now has the equivalent gate**, closed by `R-03`/ADR-012 on 2026-08-08: `jiti` makes
+`eslint.config.ts` loadable, `npm run build` runs `tsc -b` before Vite, and `npm run typecheck` exists. Both
+gates were verified by negative test — a deliberate type error fails the build before Vite runs, and a
+deliberate `console.log` is reported by lint. What this does **not** buy is automatic enforcement: nothing runs
+these commands for you until CI exists ([INFRA-01](#infra-01), `R-04`).
 
 ---
 
@@ -43,11 +46,10 @@ The frontend has no equivalent gate: `npm run lint` still cannot start ([BUILD-0
 
 | ID | Severity | Area | Issue |
 | --- | --- | --- | --- |
-| [BUILD-03](#build-03) | **High** | Tooling | `npm run lint` cannot run — `jiti` missing from `devDependencies` |
-| [BUILD-04](#build-04) | **High** | Tooling | `npm run build` does not type-check |
 | [BUILD-05](#build-05) | Medium | Perf | `mainPhoto.png` is 2.1 MB — 5.7× the entire JS bundle |
 | [BUILD-06](#build-06) | Low | Tooling | `run-coverage.ps1` measures only the unit-test project |
 | [BUILD-07](#build-07) | Low | Tooling | Node version not pinned |
+| [BUILD-08](#build-08) | Low | Tooling | `ts-node` is a devDependency nothing uses |
 | [SEC-01](#sec-01) | **Critical** | Security | No authentication at all |
 | [SEC-02](#sec-02) | **Critical** | Security | No authorization / no recipe ownership |
 | [SEC-03](#sec-03) | **High** | Security | 68 open Dependabot alerts across 14 npm packages; `axios` alone is 29 of them |
@@ -67,8 +69,8 @@ The frontend has no equivalent gate: `npm run lint` still cannot start ([BUILD-0
 | [BUG-05](#bug-05) | Medium | Contract | `updateRecipe` typed as returning a body; API returns 204 |
 | [BUG-06](#bug-06) | Medium | Frontend | `/recipes/new` is linked but has no route |
 | [BUG-07](#bug-07) | Low | API | `GET /api/recipes/{id}` missing the `:guid` route constraint |
-| [BUG-08](#bug-08) | Low | Frontend | `console.log` left in shipped code |
 | [BUG-09](#bug-09) | Low | Frontend | Error recovery does a full page reload |
+| [BUG-10](#bug-10) | Medium | Frontend | No recipe detail route, so cards are not clickable |
 | [TEST-01](#test-01) | **High** | Tests | No frontend test runner or tests |
 | [TEST-02](#test-02) | **High** | Tests | Cache invalidation has no dedicated test |
 | [TEST-03](#test-03) | Medium | Tests | Instruction ordering never asserted |
@@ -98,49 +100,6 @@ Resolved decisions and items promoted to planned work are recorded in [Settled](
 ---
 
 ## Build & tooling
-
-### BUILD-03
-**`npm run lint` cannot run on a clean install — High**
-
-```
-Error: The 'jiti' library is required for loading TypeScript configuration files.
-```
-
-**Cause.** The ESLint config is `eslint.config.ts` (TypeScript). ESLint 9 needs `jiti` to load a TS config, and
-`jiti` is **not** in `devDependencies` and is not pulled in transitively. Reproduced from a clean
-`npm install` on `main` @ `edfd057` (2026-07-26).
-
-**When it broke.** The config was `eslint.config.js` until commit `3474a8b` (2025-08-08, "Convert from
-javascript to typescript"), which renamed it to `.ts` without adding `jiti`. `git log -S'jiti'` shows the
-package has never appeared in `package.json`, so lint has been unable to start since that commit.
-
-**Impact.** Every ESLint rule the project configured — `@typescript-eslint/no-unused-vars`, `react-hooks`, and
-the type-checked rule sets — has been unenforced since then. This is why [BUG-08](#bug-08) survived.
-
-**Fix.** Either add `jiti` to `devDependencies`, or rename the config to `eslint.config.js`/`.mjs`. Adding
-`jiti` preserves the type-checked config and is the smaller change. Then run `npm run lint` and fix whatever it
-reports — that result is currently unknown and may add entries to this file.
-
-**Owner:** `03-senior-react` · **Effort:** ~10 min + unknown follow-up
-
-### BUILD-04
-**`npm run build` does not type-check — High**
-
-`"build": "vite build"` in `package.json`. Vite transpiles with esbuild and **strips types without checking
-them**, so a TypeScript error does not fail the build.
-
-**Impact.** The frontend has no automated type safety gate. Combined with [BUILD-03](#build-03), *nothing*
-currently validates the frontend in CI-equivalent terms. This matters most for the contract bugs
-([BUG-01](#bug-01)–[BUG-03](#bug-03)): fixing the TS types will surface real errors that must be caught
-somewhere.
-
-**Verified.** `npx tsc --noEmit` currently passes with 0 errors — the code is type-clean today, it is just
-unguarded.
-
-**Fix.** `"build": "tsc -b && vite build"` (the Vite React-TS template default), and add a
-`"typecheck": "tsc --noEmit"` script for fast local checks.
-
-**Owner:** `03-senior-react` · **Effort:** ~10 min
 
 ### BUILD-05
 **`mainPhoto.png` is 2.1 MB — Medium**
@@ -184,6 +143,20 @@ verified on runs Node 24.18 / npm 11.16. The .NET SDK *is* pinned (`global.json`
 
 **Owner:** `03-senior-react` · **Effort:** ~5 min
 
+### BUILD-08
+**`ts-node` is a devDependency nothing uses — Low**
+
+`ts-node@^10.9.2` sits in `recipe-manager-frontend/package.json` with no reference anywhere: no `ts-node`
+section in `tsconfig.json`, no script that invokes it, no config that loads through it. The most likely
+explanation is an earlier attempt to fix `BUILD-03` — ESLint 9 loads a TypeScript flat config through `jiti`,
+not `ts-node`, so it never had any effect.
+
+**Fix.** Remove it, then `npm run lint`, `npm run typecheck`, and `npm run build` to confirm nothing regressed.
+Left in place by `R-03`, which added `jiti` — removing an unrelated dependency in the same PR would have
+obscured which change made lint work.
+
+**Owner:** `03-senior-react` · **Effort:** ~5 min
+
 ---
 
 ## Security
@@ -215,7 +188,7 @@ Two tools, two numbers, both correct — they count different things:
 
 | Source | Reports | Counts |
 | --- | --- | --- |
-| `npm audit` | **17 vulnerabilities** (12 high, 3 moderate, 2 low) | affected *packages* |
+| `npm audit` | **18 vulnerabilities** (13 high, 3 moderate, 2 low) | affected *packages* |
 | Dependabot (`gh api repos/guillerlp/RecipeManager/dependabot/alerts`) | **68 open alerts** — 32 high, 32 medium, 4 low | one alert per *advisory per package* |
 
 Quote the Dependabot figure when talking about the repo, since that is what the GitHub UI shows. All 68 are
@@ -246,6 +219,14 @@ then be exactly what the advisory targets.
 **Fix.** `npm audit fix` claims to resolve them. Do it in its own PR, then `npm run build`, `npx tsc --noEmit`,
 and manually exercise the app — `react-router` and `vite` are majors-adjacent and this is the kind of upgrade
 that breaks routing silently.
+
+**The count moved from 17 to 18 in `R-03`, and `jiti` is not the cause.** `jiti@2.7.0` has **zero** runtime
+dependencies, no install scripts, and is MIT-licensed — it adds one dev-scope package and no transitive graph.
+What changed is that `npm install` re-resolved the tree: a hoisted, optional-peer `yaml@2.8.0` entry was dropped
+and `cosmiconfig`'s nested `yaml` now carries the advisory instead (a stack-overflow DoS on deeply nested YAML,
+reachable only through the build toolchain). Recorded here rather than fixed, because this entry's own
+instruction is that `npm audit fix` runs in its **own** PR with manual verification — `react-router` and `vite`
+are majors-adjacent and break routing silently.
 
 **Backend is clean:** `dotnet list package --vulnerable --include-transitive` reports no vulnerable packages in
 any of the six projects, and Dependabot opened zero NuGet alerts. Confirmed by both tools independently.
@@ -397,17 +378,28 @@ is worthwhile regardless.
 `[HttpGet("{id}")]` while `[HttpPut("{id:guid}")]` and `[HttpDelete("{id:guid}")]` are constrained. A malformed
 id reaches model binding instead of being rejected by routing, producing an inconsistent error shape.
 
-### BUG-08
-**`console.log` in shipped code — Low**
-
-`components/common/SearchBar/SearchBar.tsx` logs on every keystroke; `components/ui/Recipe/RecipeList/RecipeList.tsx`
-logs on every card click. Both would have been caught by ESLint had it been runnable ([BUILD-03](#build-03)).
-
 ### BUG-09
 **Error recovery does a full page reload — Low**
 
 `RecipeList`'s retry button calls `window.location.reload()`, discarding all client state. TanStack Query's
 `refetch()` is already available from `useRecipes`.
+
+### BUG-10
+**No recipe detail route, so cards are not clickable — Medium**
+
+`App.tsx` routes only `/`, `/recipes`, and `/profile`. There is no `/recipes/:id` screen, so there is nothing
+for a `RecipeCard` click to navigate to.
+
+Until `R-03`, `RecipeList` passed an `onClick` whose entire body was `console.log('Clicked recipe:', …)`. That
+made every card render as `<button aria-label="View {title} recipe">` — focusable, announced to a screen reader
+as an action, and doing nothing when activated. Removing the debug log (`BUG-08`) left a no-op handler, so the
+`onClick` was dropped and cards now render as `<article>`, which is what `RecipeCard`'s element switch is for.
+
+**Fix.** Build the detail screen, add the `/recipes/:id` route, and pass `onClick` again — `RecipeCard` already
+switches to `<button>` when it receives one. Note that the detail screen is blocked by the contract defects
+[BUG-01](#bug-01)–[BUG-03](#bug-03): it needs the real `Guid` id, `servings`, and `instructions`.
+
+**Owner:** `03-senior-react` + `07-ux-ui`
 
 ---
 
@@ -470,8 +462,9 @@ PostgreSQL, and PRs should say so explicitly.
 **No CI pipeline — High**
 
 No `.github/` directory, no workflow, nothing. Every check in
-[workflows/release-workflow.md](workflows/release-workflow.md) is manual and therefore skippable —
-[BUILD-03](#build-03) is direct evidence that an unenforced check silently rots.
+[workflows/release-workflow.md](workflows/release-workflow.md) is manual and therefore skippable — the retired
+`BUILD-03` (see [Settled](#settled)) is direct evidence that an unenforced check silently rots: `npm run lint`
+could not even *start* for eleven months and no one noticed.
 
 **Minimum useful pipeline:** `dotnet build` (already warnings-as-errors via `Directory.Build.props`, ADR-010),
 `dotnet test`, `npm ci`, `npm run typecheck`, `npm run lint`, `npm run build`. Add
@@ -640,3 +633,7 @@ Decisions that were open and are now answered, kept so they are not re-litigated
 | Package versions duplicated across `.csproj` files | **Central package management.** Ten packages were versioned in two projects each; drift resolved nearest-wins with no diagnostic. **Shipped 2026-08-04.** | ADR-011 |
 | Should a NuGet advisory fail the local build? | **Yes, accepted.** `TreatWarningsAsErrors` elevates `NU1903`, delivering `R-04`'s vulnerability gate earlier. Escape hatch recorded in ADR-010 if it becomes obstructive. | ADR-010 |
 | `RecipeManager.Api.csproj.user` committed | **Untracked**, and `*.user` added to `.gitignore` — it carried one developer's debug profile. Fixed 2026-08-04. | — |
+| `BUILD-03` — `npm run lint` could not start | **Fixed** by adding `jiti`; ESLint 9 loads a TypeScript flat config through it. Unable to start since 2025-08-08. **Shipped 2026-08-08.** | ADR-012, `R-03` |
+| `BUILD-04` — `npm run build` did not type-check | **Fixed**: `"build": "tsc -b && vite build"`, plus a `typecheck` script. **Shipped 2026-08-08.** | ADR-012, `R-03` |
+| `BUG-08` — `console.log` in shipped code | **Removed**, and `no-console` added to the ESLint config — the rule had never been configured, so the entry's claim that lint "would have caught" them was wrong. **Shipped 2026-08-08.** | ADR-012, `R-03` |
+| Was the ESLint config lintable as written? | **No.** Type-aware rules were applied to `**/*.{ts,tsx}` while `tsconfig.json` includes only `src`, so `eslint.config.ts` and `vite.config.ts` were parse errors. Typed rules now scope to `src/**`; root tooling files lint without type information. | ADR-012 |

--- a/docs/learning-mode.md
+++ b/docs/learning-mode.md
@@ -131,8 +131,8 @@ of these, point at the file.
 | Concept | Where it lives | What to notice |
 | --- | --- | --- |
 | **Server state vs. client state** | `useRecipes` (TanStack Query) vs. `useState` in `RecipePage` | Server data is cached, shared, and invalidated; UI state is local. Conflating them is why people reach for Redux unnecessarily. |
-| **Context + guard hook** | `ThemeContext` and `useTheme` | The hook throws when the provider is missing, converting a silent-undefined bug into a loud one. |
-| **Memoised context value** | `ThemeContext`'s `useMemo` + `useCallback` | Without them, every provider render gives consumers a new object and re-renders all of them. |
+| **Context + guard hook** | `contexts/ThemeContext.ts` and `useTheme` | The hook throws when the provider is missing, converting a silent-undefined bug into a loud one. Note the context is created with **no default value** — that is what makes the throw reachable. It had one until `R-03`, and the guard was dead code the whole time. |
+| **Memoised context value** | `ThemeProvider`'s `useMemo` + `useCallback` | Without them, every provider render gives consumers a new object and re-renders all of them. |
 | **Derived state via `useMemo`** | `RecipeList.filteredRecipes` | Filtering is computed from props and state, never stored in its own `useState` — no synchronisation bug is possible. |
 | **Semantic element selection** | `RecipeCard` rendering `<article>` or `<button>` by whether `onClick` exists | Accessibility falls out of the element choice instead of being bolted on with ARIA. |
 | **Design tokens and theming** | `styles/themes/*.css`, `data-theme` on `<html>` | One attribute swaps the whole palette because no component hard-codes a colour. |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,21 +32,11 @@ that are *wrong* with what already exists.
 
 These are cheap, unblock everything else, and each one removes a whole class of future bug.
 
-### R-03
-**Fix the frontend toolchain** · `03-senior-react` · ~30 min
-
-Three separate holes that together mean the frontend has *no* automated quality gate:
-
-1. Add `jiti` to `devDependencies` so `npm run lint` can actually run (`BUILD-03`).
-2. `"build": "tsc -b && vite build"` and add `"typecheck": "tsc --noEmit"` (`BUILD-04`).
-3. Run the newly-working lint and fix what it reports — the result is currently unknown.
-
-Everything else on the frontend roadmap depends on this.
-
 ### R-04
 **CI pipeline** · `01-architect` → implementation · ~3 h
 
-Nothing enforces any checklist today. `BUILD-03` is the proof: a check that nobody runs silently stops working.
+Nothing enforces any checklist today. `R-03` is the proof: `npm run lint` could not start for eleven months and
+nothing reported it, because a check that nobody runs and a check that passes look the same from outside.
 
 Minimum GitHub Actions workflow on every PR:
 
@@ -55,6 +45,9 @@ dotnet build (already warnings-as-errors, ADR-010) · dotnet test
 npm ci · npm run typecheck · npm run lint · npm run build
 dotnet list package --vulnerable --include-transitive · npm audit
 ```
+
+Every one of those npm scripts now exists and passes — `R-03`/ADR-012 made them runnable. This item is what
+makes anyone actually run them.
 
 Dependabot **alerting** is already on (68 open alerts today) but nothing acts on it. Add Dependabot
 **pull requests** for both ecosystems and fail the build on high-severity alerts — that is what turns a
@@ -119,8 +112,8 @@ Zero frontend tests exist (`TEST-01`). **Vitest + React Testing Library + jsdom*
 `vite.config.ts` aliases directly, so setup is minimal.
 
 First tests, in priority order: `RecipeCard.formatDuration`/`getISODuration` boundaries; `RecipeList` filtering
-and its four states; `ThemeContext` persistence and the `useTheme` guard; `NavLink` active-state matching.
-Blocked by `R-03`.
+and its four states; `ThemeProvider` persistence and the `useTheme` guard; `NavLink` active-state matching.
+Unblocked — `R-03` shipped 2026-08-08.
 
 ### R-08
 **Close the cache-invalidation test gap** · `06-qa-tester` · ~2 h

--- a/docs/specs/001-frontend-toolchain-gate.md
+++ b/docs/specs/001-frontend-toolchain-gate.md
@@ -1,0 +1,214 @@
+# Spec: Fix the frontend toolchain (R-03)
+
+| | |
+| --- | --- |
+| **ID** | `001` |
+| **Status** | shipped |
+| **Author** | `00-leader` |
+| **Created** | 2026-08-08 |
+| **Branch** | `chore/r-03-frontend-toolchain` |
+
+---
+
+## 1. Context
+
+The frontend has no working automated quality gate. `npm run lint` **cannot start** on a clean install because
+the ESLint config is `eslint.config.ts` and ESLint 9 needs `jiti` to load a TypeScript config, which is not a
+dependency (`BUILD-03`) — reproduced on this branch, and true since commit `3474a8b` (2025-08-08). `npm run
+build` runs `vite build`, which transpiles with esbuild and **strips types without checking them**, so a
+TypeScript error cannot fail the build either (`BUILD-04`).
+
+The backend was closed off in exactly this way by `R-02`/ADR-010: warnings became build failures. The frontend
+still has nothing equivalent, and `BUG-08` (`console.log` in shipped code) is the proof that the unenforced
+rules rot — every ESLint rule this project configured has been unenforced for eleven months.
+
+## 2. Goal
+
+Make `npm run lint` and type-checking actually run, and fix everything the newly-working lint reports, so the
+frontend has a gate that can be wired into CI by `R-04`.
+
+## 3. In scope
+
+- [x] Add `jiti` to `devDependencies` so `eslint.config.ts` loads (`BUILD-03`).
+- [x] `"build"` type-checks before bundling, and a `"typecheck"` script exists for fast local checks
+      (`BUILD-04`).
+- [x] Make the ESLint config self-consistent: the type-checked rule sets are configured with
+      `project: ['./tsconfig.json']`, whose `include` is `["src"]` only, so the root config files are linted
+      with type information they have no project for.
+- [x] Run `npm run lint` and fix every error it reports. `BUG-08` (`console.log` in `SearchBar.tsx` and
+      `RecipeList.tsx`) is expected to be among them and is closed here.
+- [x] Update `docs/known-issues.md`, `docs/roadmap.md`, `README.md`, `CLAUDE.md`, and the agent docs that
+      currently instruct agents to skip lint.
+
+**Added during implementation**, because turning the linter on reported them:
+
+- [x] `no-console` added to the ESLint config as an error — it had **never been configured**, so the claim in
+      `BUG-08` that lint would have caught the `console.log`s was wrong. Recording the rule is what actually
+      closes that defect.
+- [x] `contexts/ThemeContext.tsx` split into `ThemeContext.ts` (context) + `ThemeProvider.tsx` (component), as
+      `react-refresh/only-export-components` requires, and the context's default value removed so `useTheme`'s
+      guard is reachable. `Footer` switched from `useContext(ThemeContext)` to `useTheme()`.
+- [x] `RecipeList` no longer passes an `onClick` that does nothing, so cards render `<article>` instead of a
+      `<button>` that announces an action and performs none. New `BUG-10` tracks the missing detail route.
+- [x] `*.tsbuildinfo` gitignored — `tsc -b` writes incremental build state.
+
+## 4. Out of scope
+
+- **The Vitest / React Testing Library setup** — that is `R-07`, blocked by this item, and adding a test runner
+  is a second dependency decision with its own ADR.
+- **The CI workflow that runs these commands** — `R-04`. This item only makes the commands runnable; nothing
+  enforces them until CI exists.
+- **`npm audit fix` / the 68 Dependabot alerts** (`SEC-03`) — a separate PR by instruction of that entry, since
+  `react-router` and `vite` upgrades break routing silently and must be exercised manually.
+- **Node version pinning** (`BUILD-07`) and the 2.1 MB `mainPhoto.png` (`BUILD-05`) — adjacent tooling defects,
+  deliberately left open so this diff stays reviewable.
+- **Any behavioural change to the app.** Lint fixes that would alter runtime behaviour beyond removing debug
+  logging are to be reported, not applied.
+
+## 5. Open questions
+
+Resolved without blocking; each is recorded as an assumption in section 14.
+
+| # | Question | Recommended default | Answer |
+| --- | --- | --- | --- |
+| 1 | Add `jiti`, or rename the config to `eslint.config.js`? | Add `jiti` — keeps the type-checked config | Add `jiti` (ADR-012) |
+| 2 | If lint reports errors that need real code changes, fix here or split? | Fix mechanical ones here; report anything behavioural | Fixed here. Two changes are behaviour-visible and are called out in section 14: the theme context now throws outside its provider, and recipe cards render `<article>` |
+| 3 | Should lint failures become blocking now? | Yes — the scripts exist and the pre-merge checklist gains a step; true enforcement waits for `R-04` | Yes |
+
+## 6. Domain impact
+
+- **New/changed entities:** none
+- **New/changed properties on `Recipe`:** none
+- **New/changed invariants:** none
+- **New/changed shape validation:** none
+- **Migration required:** no
+- **Known limitations touched:** none
+
+No backend file is touched by this spec.
+
+## 7. API impact
+
+None. No endpoint, DTO, route, or cache key changes. `RecipeDto` is untouched, so `08-api-contract` is not
+involved — the contract defects `BUG-01`–`BUG-05` remain open and are **not** fixed here.
+
+## 8. Frontend impact
+
+- **New routes:** none
+- **New/changed components:** none created. `SearchBar.tsx` and `RecipeList.tsx` lose their `console.log`
+  calls; any further edits are whatever lint requires and are listed in the PR.
+- **New/changed hooks:** none
+- **States to design:** none — no UI change. Lint and type-check output are the only observable difference.
+- **Design tokens needed:** existing only
+
+## 9. Architecture impact
+
+- **ADR required:** yes → ADR-012 in [../architecture.md](../architecture.md) (new npm devDependency, and the
+  build script becomes a gate)
+- **New dependency:** `jiti` (devDependency) — the loader ESLint 9 uses to evaluate a TypeScript flat config.
+  It replaces nothing; it is the missing half of a choice already made in 2025.
+- **Layer/dependency changes:** none. Frontend tooling only; no backend project reference changes.
+- **New DI registrations:** none
+
+### Alternatives considered
+
+| Option | Optimises for | Why not chosen here |
+| --- | --- | --- |
+| Rename `eslint.config.ts` → `.js`/`.mjs` | Zero new dependencies; ESLint loads plain JS natively | Loses type checking *of the config itself* and the typed `tseslint.config()` helper. The config already uses `tseslint.config(...)`, so the project has chosen TS config; reversing that to avoid a dev-only loader trades a real capability for a dependency that never ships to the browser. |
+| Keep `ts-node` and hope it loads the config | No change at all | Factually wrong: ESLint 9 hard-codes `jiti`, not `ts-node`, and the error message says so. `ts-node` sitting in `devDependencies` is very likely a previous attempt at this fix that did not work — evidence that the missing piece was guessed at rather than read. |
+| `"build": "tsc --noEmit && vite build"` | One fewer TS build mode to understand; no `.tsbuildinfo` on disk | `tsc -b` is the Vite React-TS template default and is incremental, so repeat builds are cheaper. Both are correct here because there is a single non-composite `tsconfig.json`; the choice is verified by running it, not assumed. |
+| Fix lint errors in a follow-up PR | A smaller, purely-additive diff | The point of the item is a *working* gate. A gate merged red is not a gate, and `BUILD-03` is this repo's own evidence that a check nobody has seen pass gets ignored. |
+
+- **Pattern applied:** *make the invalid state unrepresentable at build time* — the same move as ADR-010's
+  `TreatWarningsAsErrors`, applied to the half of the codebase that ADR-010 could not reach.
+- **What this makes harder:** every future frontend PR must satisfy the type-checked ESLint rule sets, which are
+  strict (`recommendedTypeChecked` + `stylisticTypeChecked`). A quick experimental commit now costs more. That
+  friction is the mechanism, not a side effect — identical to the cost recorded in ADR-010.
+
+## 10. Security impact
+
+- **New user-controlled input:** none
+- **User content rendered in the SPA:** unchanged
+- **File upload:** no
+- **Auth/ownership implications:** none — this item neither improves nor worsens `SEC-01`/`SEC-02`
+- **Config/secrets touched:** none. No `.env` file, no connection string, no `VITE_API_URL` change.
+- **Standing gaps affected:** adds one npm devDependency, so `SEC-03`'s surface grows by one package —
+  build-scope only, never shipped to the browser. `05-security-reviewer` reviews on that basis alone; the
+  trigger list in [../agents/05-security-reviewer.md](../agents/05-security-reviewer.md) is otherwise not fired.
+
+**Review outcome.** `jiti@2.7.0`: MIT, **zero** dependencies, no install scripts — it adds one dev-scope package
+and no transitive graph. `npm audit` moved from 17 to 18 affected packages, which is **not** `jiti`: `npm
+install` re-resolved a hoisted optional-peer `yaml@2.8.0` into `cosmiconfig`'s nested copy, which carries a
+dev-scope DoS advisory. Recorded in `SEC-03` rather than fixed here, per that entry's own instruction that
+`npm audit fix` gets its own PR. No secret, config, CORS, or connection-string change is in this diff.
+
+## 11. Acceptance criteria
+
+- [ ] Given a clean `node_modules`, when `npm ci && npm run lint` runs, then ESLint **starts** and exits 0.
+- [ ] Given a deliberately introduced type error, when `npm run build` runs, then it **fails** before Vite
+      bundles anything. (The negative test — a gate never seen rejecting anything is indistinguishable from no
+      gate. See the 2026-08-04 decisions-log entry.)
+- [ ] Given a deliberately introduced `console.log`, when `npm run lint` runs, then it is reported.
+- [ ] `npm run typecheck` exists and exits 0.
+- [ ] No `console.log` remains in `recipe-manager-frontend/src/`.
+- [ ] `dotnet build` still reports 0 warnings and `dotnet test` still reports 84 passing — this PR must not
+      touch the backend, and the numbers prove it.
+
+## 12. Test plan
+
+- **Domain unit tests:** none — no domain change.
+- **Handler unit tests:** none — no handler change.
+- **Integration tests:** none. Backend suite is run only as a regression guard.
+- **Not covered, and why:** there is still **no frontend test runner** (`TEST-01`), so nothing asserts app
+  behaviour after the lint fixes. That is `R-07`, which this item unblocks. Removing a `console.log` cannot
+  change behaviour, but a lint autofix elsewhere could, which is why autofix output is reviewed by hand rather
+  than trusted.
+- **Manual verification:** `npm run dev`, load `/` and `/recipes` in both light and dark themes, exercise the
+  search box and click a card — the two files losing `console.log` are exactly those paths.
+
+## 13. Agents involved
+
+| Step | Agent | Deliverable |
+| --- | --- | --- |
+| 1 | `00-leader` | this spec |
+| 2 | `01-architect` | ADR-012 — the `jiti` dependency and the build-as-gate decision |
+| 3 | `03-senior-react` | `package.json` scripts + devDependency, ESLint config fix, lint fixes |
+| 4 | `06-qa-tester` | negative tests for both new gates; coverage statement |
+| 5 | `04-code-reviewer` | review |
+| 6 | `05-security-reviewer` | dependency-surface review only |
+
+Rows deleted: `02-senior-csharp` (no backend file is in scope), `08-api-contract` (no contract change),
+`07-ux-ui` (no visual change) — see section 4.
+
+## 14. Assumptions made
+
+- **Wrong, and corrected in flight:** the assumption was that lint findings would be mechanical. Two were not,
+  and both were applied rather than deferred, because leaving them meant leaving the linter red:
+  - `useTheme`'s missing-provider guard was **dead code** — the context had a default value, so `useContext`
+    never returned `undefined`. Removing the default makes the guard fire. A component rendered outside
+    `ThemeProvider` now throws instead of silently receiving the light theme. `Footer` was the only direct
+    `useContext` consumer and now goes through the hook.
+  - `RecipeCard` no longer receives an `onClick` from `RecipeList`, so cards render `<article>` rather than a
+    `<button>` announced as "View {title} recipe" that did nothing. Tracked as `BUG-10` so the detail screen
+    re-adds it.
+- Both were verified in the browser against a running API in light and dark themes.
+- Lint becomes a **documented** pre-merge step now and a **enforced** one when `R-04` lands. Nothing in this PR
+  can force anyone to run it.
+- `ts-node` is left in `devDependencies` in this PR. Removing it is plausible cleanup but is not needed for the
+  gate to work, and unused-dependency removal is its own change — recorded as a follow-up.
+
+## 15. Follow-ups
+
+- Remove the apparently-unused `ts-node` devDependency (new `BUILD-08`).
+- Add `npm run lint` and `npm run typecheck` to the CI workflow — `R-04`.
+- Install Vitest and write the first frontend tests — `R-07`, unblocked by this item.
+- `SEC-03`, `BUILD-05`, `BUILD-07` remain open by design.
+
+## 16. Known issues and roadmap items touched
+
+- Fixes: `BUILD-03`, `BUILD-04`, `BUG-08`, roadmap `R-03`
+- Adds: `BUILD-08` (unused `ts-node`), `BUG-10` (no recipe detail route, cards not clickable)
+- Unblocks: `R-07` (frontend tests), and gives `R-04` the npm scripts it calls
+- Depends on: nothing. This is the Phase 1 item everything else on the frontend roadmap (`R-07`, `R-09`) waits
+  behind, and `R-04` consumes.
+- On the [deploy gate](../roadmap.md#deploy-gate)? no — but `R-04`, which is on it, cannot be written until
+  these commands run.

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -64,19 +64,23 @@ Both test projects set `<Using Include="Xunit" />`, so `using Xunit;` is implici
 | `@tanstack/react-query-devtools` | 5.85 | mounted when `process.env.NODE_ENV === 'development'` |
 | `axios` | 1.10 | single `AxiosInstance` in `services/recipeService.ts` |
 | `react-router-dom` | 7.7 | `BrowserRouter` + 3 routes in `App.tsx` |
-| `eslint` 9 + `typescript-eslint` 8.39 | | flat config, `recommendedTypeChecked` + `stylisticTypeChecked` |
+| `eslint` 9 + `typescript-eslint` 8.39 | | flat config, `recommendedTypeChecked` + `stylisticTypeChecked` scoped to `src/**`, plus `no-console` |
+| `jiti` | 2.7 | dev-only loader ESLint 9 uses to evaluate `eslint.config.ts`. Without it ESLint cannot start at all — ADR-012 |
 
-### npm scripts — two are broken or misleading
+### npm scripts
 
 | Script | Command | Reality |
 | --- | --- | --- |
 | `dev` | `vite` | works — port 3000 |
-| `build` | `vite build` | succeeds, but **does not type-check** (esbuild strips types without checking). `BUILD-04` |
-| `lint` | `eslint .` | **fails to start** on a clean install — `eslint.config.ts` needs `jiti`, which is not a dependency. `BUILD-03` |
+| `build` | `tsc -b && vite build` | type-checks first, so a type error fails before Vite bundles (ADR-012) |
+| `typecheck` | `tsc --noEmit` | the fast local loop; 0 errors |
+| `lint` | `eslint .` | runs, 0 problems (ADR-012) |
 | `preview` | `vite preview` | works |
 
-There is no `typecheck` script and no `test` script. Run `npx tsc --noEmit` manually until `BUILD-04` is fixed —
-it currently passes with 0 errors. See [known-issues.md](known-issues.md).
+There is still no `test` script — no frontend test runner exists (`TEST-01`, planned as `R-07`). And note what
+the three working scripts do *not* give you: nothing runs them on your behalf until CI exists (`INFRA-01`,
+`R-04`). `ts-node` remains in `devDependencies` with nothing using it — `BUILD-08` in
+[known-issues.md](known-issues.md).
 
 Dependabot reports **68 open alerts** across 14 npm packages (32 high, 32 medium, 4 low); `npm audit` describes
 the same set as **17 affected packages**, because it counts packages while Dependabot counts advisories.

--- a/docs/workflows/release-workflow.md
+++ b/docs/workflows/release-workflow.md
@@ -65,15 +65,16 @@ Run from `RecipeManager/`. Everything here is manual — nothing enforces it.
    ```
    Currently **84 passing** — 70 unit + 14 integration.
 
-3. **Frontend builds and type-checks.** From `recipe-manager-frontend/`:
+3. **Frontend builds, type-checks, and lints.** From `recipe-manager-frontend/`:
    ```bash
    npm run build
    ```
    ```bash
-   npx tsc --noEmit
+   npm run lint
    ```
-   `npm run build` does **not** type-check (`BUILD-04`), so `tsc` must be run separately. `npm run lint` cannot
-   run at all on a clean install (`BUILD-03`) — once that is fixed, add it here.
+   `npm run build` now runs `tsc -b` first, so it type-checks (ADR-012); `npm run typecheck` is the same check
+   without bundling, for a faster loop. Lint must report **0 problems** — it runs since `jiti` was added, and
+   `no-console` is an error.
 
 4. **Migrations.** If the model changed, exactly one new migration is committed together with its
    `.Designer.cs` and the updated `AppDbContextModelSnapshot.cs`. Confirm `Up` and `Down` are both correct —
@@ -163,6 +164,5 @@ deploy — `INFRA-03` in [../known-issues.md](../known-issues.md).
 | No rollback or database-restore procedure | `INFRA-03` | `01-architect` |
 | No frontend deployment target or production `VITE_API_URL` | `INFRA-04`, `SEC-12` | `03-senior-react` + `01-architect` |
 | No frontend test runner, so nothing to gate on | `TEST-01` | `06-qa-tester` |
-| `npm run lint` cannot run; `npm run build` does not type-check | `BUILD-03`, `BUILD-04` | `03-senior-react` |
 
 Full detail for each: [../known-issues.md](../known-issues.md).


### PR DESCRIPTION
## What
Adds `jiti` so `npm run lint` can start, makes `npm run build` type-check (`tsc -b && vite build`), adds a
`typecheck` script, and fixes everything the newly-working linter reported.

## Why
docs/specs/001-frontend-toolchain-gate.md — roadmap item `R-03`, the Phase 1 blocker for `R-04` (CI) and
`R-07` (frontend tests). ADR-012.

## Layers touched
Frontend / Docs. **No backend file is in the diff.**

## Migration
None.

## Contract impact
None. `RecipeDto`, `types/recipe.ts`, and `recipeService.ts` are untouched — `BUG-01`–`BUG-05` remain open.

## Verification
- dotnet build: 0 warnings
- dotnet test: 84/84 passing (70 unit + 14 integration)
- npm run lint: 0 problems (was: could not start)
- npm run typecheck: 0 errors
- npm run build: passes, and now fails on a type error
- Negative tests, both gates: a deliberate `const x: number = "s"` fails `npm run build` **before** Vite runs;
  a deliberate `console.log` is reported by lint.
- Manual: dev server against a running API on PostgreSQL. Loading / error / empty / populated states, search
  match and no-match, theme toggle and persistence across reload, light and dark. A temporary recipe was
  created via `POST /api/recipes` for the populated state and deleted afterwards (`DELETE` → 204, list empty).

## What turning the linter on actually found
Not just style — three of the twelve errors were real defects:

1. **`useTheme`'s guard was dead code.** `ThemeContext` was created *with* a default value, so `useContext`
   never returned `undefined` and `if (!ctx) throw` was unreachable. The context is now
   `createContext<ThemeContextType | undefined>(undefined)`. `Footer` called `useContext(ThemeContext)`
   directly, bypassing the hook — it now uses `useTheme()`.
2. **`no-console` had never been configured**, so `BUG-08`'s claim that lint "would have caught" the
   `console.log`s was wrong. The rule is now an error (`warn`/`error` allowed).
3. **Recipe cards were fake buttons.** `RecipeList` passed an `onClick` whose whole body was the debug log, so
   every card rendered `<button aria-label="View X recipe">` that did nothing when activated. Removing the log
   left a no-op, so the `onClick` is gone and cards render `<article>` — which is what `RecipeCard`'s element
   switch exists for. Tracked as `BUG-10`.

Also: `contexts/ThemeContext.tsx` is split into `ThemeContext.ts` + `ThemeProvider.tsx`
(`react-refresh/only-export-components`), and the unused `Recipe` import that surfaced was caught by **`tsc`,
not ESLint** — `no-unused-vars` uses `varsIgnorePattern: '^[A-Z_]'`, which exempts every PascalCase binding.

## Known issues / roadmap
Fixes:      `BUILD-03`, `BUILD-04`, `BUG-08`, roadmap `R-03` (all deleted; recorded in Settled)
Adds:       `BUILD-08` (unused `ts-node`), `BUG-10` (no recipe detail route, so cards are not clickable)
Unblocks:   `R-07`; gives `R-04` the npm scripts it calls
Deploy gate: none closed directly

## Security
`jiti@2.7.0`: MIT, zero dependencies, no install scripts, dev-scope only. `npm audit` went 17 → 18 affected
packages, which is **not** `jiti` — `npm install` re-resolved a hoisted optional-peer `yaml@2.8.0` into
`cosmiconfig`'s nested copy, which carries a dev-scope DoS advisory. Recorded in `SEC-03`, not fixed here,
because that entry requires `npm audit fix` to land in its own PR with manual verification.

## Follow-ups
- `npm audit fix` (`SEC-03`) — deliberately its own PR.
- Remove `ts-node` (`BUILD-08`).
- Recipe detail route so cards become clickable again (`BUG-10`), blocked by `BUG-01`–`BUG-03`.
- Nothing enforces these commands until CI exists (`INFRA-01`, `R-04`). This PR makes the gate possible, not
  automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
